### PR TITLE
Finalize v0.1: examples, test categories, renderer protocol, image IO, CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,26 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    # Lint is platform-independent and needs no MLX, so run it fast on Linux.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - name: Ruff lint
+        run: uvx ruff check .
+      - name: Ruff format
+        run: uvx ruff format --check .
+
   test:
+    needs: lint
     # macos-14+ runners are Apple Silicon, required for MLX (Metal GPU).
     runs-on: macos-14
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
@@ -21,5 +37,9 @@ jobs:
           enable-cache: true
       - name: Install
         run: uv sync
-      - name: Run tests
-        run: uv run pytest tests/ -v
+      - name: Smoke tests
+        run: uv run pytest tests/ -m smoke -v
+      - name: Unit + data tests
+        run: uv run pytest tests/ -m "unit or data" -v
+      - name: Behavior tests
+        run: uv run pytest tests/ -m behavior -v

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ MLX3D brings the PyTorch3D workflow to Macs: batched 3D data structures, cameras
 - **Mesh rendering** — differentiable soft triangle rasterization, UV texture sampling for OBJ/MTL assets, and scalar-field mesh extraction.
 - **Gaussian Splatting** — a Metal translation of the reference CUDA rasterizer (tile-based forward & backward kernels wrapped in `mx.custom_function`), EWA projection, spherical harmonics, adaptive density control, COLMAP loading, and standard 3DGS `.ply` checkpoints. ~30 FPS forward at 720p with 100k Gaussians on an M-series GPU.
 - **Interactive viewer** — `mlx3d-view point_cloud.ply` opens a browser viewer with orbit/pan/zoom; frames are rendered on the Apple GPU by the Metal rasterizer and streamed live. Works for NeRFs too.
-- **IO** — OBJ and PLY (ascii + binary), including Gaussian Splatting checkpoint layouts.
+- **IO** — OBJ and PLY (ascii + binary, including Gaussian Splatting checkpoint layouts), plus one-line image `save_image` / `load_image` for any renderer output.
+- **Composable & extensible** — every image renderer is a plain callable `(camera, scene) -> {"image", "alpha", "depth"}` (the [`Renderer`](src/mlx3d/renderer/protocols.py) protocol), so you can drop in your own rasterizer, shader, or ray tracer and reuse the rest of the pipeline — no base classes to subclass.
 
 ## Installation
 
@@ -53,6 +54,26 @@ mlx3d-view outputs/gs/point_cloud.ply   # inspect the result interactively
 ```
 
 More in the docs: [mesh optimization](https://amirhossein-razlighi.github.io/mlx3D/tutorials/mesh_optimization/), [point cloud fitting](https://amirhossein-razlighi.github.io/mlx3D/tutorials/pointcloud_fitting/), [NeRF](https://amirhossein-razlighi.github.io/mlx3D/tutorials/nerf/), [Gaussian Splatting](https://amirhossein-razlighi.github.io/mlx3D/tutorials/gaussian_splatting/).
+
+## Examples
+
+The [`examples/`](examples/) folder has runnable scripts for every core feature.
+The self-contained ones generate their own synthetic data — no downloads — and
+finish in seconds:
+
+```bash
+uv run python examples/render_mesh.py        # soft mesh rasterization
+uv run python examples/raytrace_volume.py    # ray casting + volume rendering
+uv run python examples/extract_mesh.py       # marching cubes from an SDF
+uv run python examples/fit_pointcloud.py     # point-cloud optimization
+uv run python examples/fit_mesh.py           # mesh fitting (chamfer + regularizers)
+uv run python examples/fit_nerf.py           # train a small NeRF
+uv run python examples/fit_gaussians.py      # fit 3D Gaussians
+uv run python examples/extend_renderer.py    # plug in a custom renderer
+```
+
+See [`examples/README.md`](examples/README.md) for the full list, including the
+COLMAP/Blender training scripts.
 
 ## Development
 

--- a/docs/tutorials/extending.md
+++ b/docs/tutorials/extending.md
@@ -1,0 +1,87 @@
+# Extending MLX3D
+
+MLX3D is built to be extended without ceremony. There are no renderer base
+classes to subclass and no registry to register with — the library leans on a
+single convention and ordinary Python callables.
+
+## The renderer convention
+
+Every image-space renderer in MLX3D — [`render_mesh_soft`][mlx3d.renderer.render_mesh_soft],
+[`render_points`][mlx3d.renderer.render_points], and
+[`GaussianModel.render`][mlx3d.splatting.GaussianModel] — is just a callable:
+
+```python
+renderer(camera, scene, **options) -> {"image": ..., "alpha": ..., "depth": ...}
+```
+
+That shape is captured by the [`Renderer`][mlx3d.renderer.Renderer] protocol and
+the [`RenderOutput`][mlx3d.renderer.RenderOutput] dict. Because it is a
+`typing.Protocol`, your own functions satisfy it automatically — you only use it
+as a type hint, never as a parent class.
+
+## Writing a custom renderer
+
+Suppose you want a renderer that shades a mesh by its surface normals. Write a
+function with the right shape and you are done — it is differentiable and works
+with everything else (saving, the viewer, turntable loops):
+
+```python
+import mlx.core as mx
+from mlx3d.cameras import Camera
+from mlx3d.renderer import RenderOutput, render_mesh_soft
+from mlx3d.structures import Meshes
+
+
+def render_normals(camera: Camera, mesh: Meshes, **kwargs) -> RenderOutput:
+    normals = mesh.verts_normals_packed()
+    colors = 0.5 * normals + 0.5  # map [-1, 1] -> [0, 1]
+    return render_mesh_soft(camera, mesh, verts_colors=colors, **kwargs)
+```
+
+Anything that accepts a `Renderer` now accepts `render_normals`:
+
+```python
+from mlx3d.io import save_image
+
+
+def turntable(renderer, mesh, *, frames=8, size=256):
+    for i in range(frames):
+        cam = Camera.look_at(
+            eye=(2.4 * mx.cos(mx.array(i / frames * 6.28)).item(), 1.4,
+                 2.4 * mx.sin(mx.array(i / frames * 6.28)).item()),
+            at=(0, 0, 0), fov=45.0, width=size, height=size,
+        )
+        out = renderer(cam, mesh, sigma=3e-3)
+        save_image(f"frame_{i:02d}.png", out["image"])
+
+
+turntable(render_normals, my_mesh)   # the same loop drives any renderer
+```
+
+A complete, runnable version of this is in
+[`examples/extend_renderer.py`](https://github.com/amirhossein-razlighi/mlx3D/blob/main/examples/extend_renderer.py).
+
+## Building your own pipeline from the pieces
+
+If you need lower-level control, compose the public building blocks directly
+instead of using a high-level renderer. For example, a custom volume renderer
+that uses your own field:
+
+```python
+from mlx3d.renderer import sample_along_rays, volume_render
+
+def render_my_field(camera, field, near, far, samples=96) -> dict:
+    o, d = camera.generate_rays()
+    h, w = o.shape[:2]
+    pts, t = sample_along_rays(o.reshape(-1, 3), d.reshape(-1, 3), near, far, samples)
+    density, rgb = field(pts)                       # your model / closure
+    out = volume_render(density, rgb, t, d.reshape(-1, 3))
+    return {"image": out["rgb"].reshape(h, w, 3), "alpha": out["acc"].reshape(h, w)}
+```
+
+The same approach works for the Gaussian Splatting stack: `project_gaussians`,
+`bin_gaussians`, and `rasterize` are all exported from `mlx3d.splatting`, so you
+can assemble a custom splatting pass while keeping the Metal kernels.
+
+Everything stays differentiable end to end, so any pipeline you build this way
+can be dropped straight into an MLX optimization loop.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,46 @@
+# MLX3D examples
+
+Every script here is standalone — run it straight from a clone with
+[`uv`](https://docs.astral.sh/uv/):
+
+```bash
+uv run python examples/render_mesh.py
+```
+
+Outputs (images, meshes, point clouds) are written to `outputs/` by default;
+pass `--out` to change the path.
+
+## Self-contained (no downloads, run anywhere)
+
+These generate their own synthetic data in-process and finish in seconds on an
+Apple-Silicon Mac — ideal for a first look or for CI.
+
+| Script | Feature | What it does |
+| --- | --- | --- |
+| [`render_mesh.py`](render_mesh.py) | Rasterization | Soft-rasterize a position-colored icosphere with `render_mesh_soft`. |
+| [`raytrace_volume.py`](raytrace_volume.py) | Ray tracing | Cast camera rays through an analytic radiance field and composite with `volume_render`. |
+| [`extract_mesh.py`](extract_mesh.py) | Mesh extraction | Recover a mesh from an implicit SDF with `marching_cubes`, save OBJ, render it. |
+| [`fit_pointcloud.py`](fit_pointcloud.py) | Point-cloud optimization | Fit a noisy point cloud to a target shape with chamfer distance. |
+| [`fit_mesh.py`](fit_mesh.py) | Mesh fitting | Deform an icosphere onto a target with chamfer + mesh regularizers. |
+| [`fit_nerf.py`](fit_nerf.py) | NeRF | Train a compact NeRF on synthetic views, render a held-out view. |
+| [`fit_gaussians.py`](fit_gaussians.py) | Gaussian splatting | Fit 3D Gaussians to synthetic views with the real `GaussianTrainer`. |
+| [`extend_renderer.py`](extend_renderer.py) | Extensibility | Plug a custom renderer into the pipeline via the `Renderer` protocol. |
+
+## Real-scene training (bring your own dataset)
+
+These take a COLMAP or NeRF-synthetic (Blender) scene. They share the data
+loaders in `mlx3d.datasets`.
+
+| Script | Feature | Data |
+| --- | --- | --- |
+| [`train_nerf.py`](train_nerf.py) | NeRF | A NeRF-synthetic scene, e.g. `nerf_synthetic/lego`. |
+| [`train_gaussian_splatting.py`](train_gaussian_splatting.py) | Gaussian splatting | A COLMAP scene (`sparse/0` + `images`) or a Blender scene. |
+| [`benchmark_gaussian_splatting.py`](benchmark_gaussian_splatting.py) | Profiling | A COLMAP scene; reports startup/train/render timings and memory. |
+
+## Writing your own
+
+Every image renderer in MLX3D is just a callable
+`(camera, scene) -> {"image", "alpha", "depth"}` (the
+[`Renderer`](../src/mlx3d/renderer/protocols.py) protocol). `extend_renderer.py`
+shows how to drop your own shading pass into the same pipeline — saving, the
+viewer, turntable loops — without subclassing anything.

--- a/examples/benchmark_gaussian_splatting.py
+++ b/examples/benchmark_gaussian_splatting.py
@@ -269,7 +269,9 @@ def main() -> None:
         method=args.method,
         white_background=white_bg,
         densify_from=args.densify_from,
-        densify_until=args.densify_until if args.densify_until is not None else max(args.steps // 2, 0),
+        densify_until=args.densify_until
+        if args.densify_until is not None
+        else max(args.steps // 2, 0),
         densify_every=args.densify_every,
         densify_grad_threshold=args.densify_grad_threshold,
         mcmc_relocate_frac=args.mcmc_relocate_frac,
@@ -301,11 +303,13 @@ def main() -> None:
             step_times.append(dt)
             losses.append(float(info["loss"]))
             if info["densify"] is not None:
-                densify_events.append({
-                    "step": int(info["step"]),
-                    "wall_time_s": float(dt),
-                    **info["densify"],
-                })
+                densify_events.append(
+                    {
+                        "step": int(info["step"]),
+                        "wall_time_s": float(dt),
+                        **info["densify"],
+                    }
+                )
         else:
             warmup_step_times.append(dt)
 

--- a/examples/extend_renderer.py
+++ b/examples/extend_renderer.py
@@ -1,0 +1,88 @@
+"""Plug your own renderer into the MLX3D pipeline (no data needed).
+
+MLX3D's image renderers are just callables ``(camera, scene) -> RenderOutput``
+(see :class:`mlx3d.renderer.Renderer`). That means you can drop in a custom
+shading pass without subclassing anything and reuse the rest of the pipeline —
+here, the same :func:`mlx3d.io.save_image` sink and a generic turntable loop
+that accepts *any* renderer.
+
+This defines a normal-shaded renderer and runs it side by side with the
+built-in soft rasterizer.
+
+Usage:
+    python examples/extend_renderer.py [--size 256]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image
+from mlx3d.renderer import Renderer, RenderOutput, render_mesh_soft
+from mlx3d.structures import Meshes
+from mlx3d.utils import ico_sphere
+
+
+def render_normals(camera: Camera, mesh: Meshes, **kwargs) -> RenderOutput:
+    """A custom renderer: shade each surface point by its world-space normal.
+
+    Satisfies the :class:`~mlx3d.renderer.Renderer` protocol simply by taking a
+    camera and returning ``image``/``alpha``/``depth``. Internally it reuses the
+    library's soft rasterizer with per-vertex colors set to the normals, so it
+    is differentiable and tile-free like everything else in the pipeline.
+    """
+    normals = mesh.verts_normals_packed()
+    verts_colors = 0.5 * normals + 0.5  # map [-1, 1] -> [0, 1]
+    return render_mesh_soft(camera, mesh, verts_colors=verts_colors, **kwargs)
+
+
+def turntable(renderer: Renderer, mesh: Meshes, *, size: int, azim: float) -> RenderOutput:
+    """Generic driver that works with ANY renderer satisfying the protocol."""
+    camera = Camera.look_at(
+        eye=(
+            2.4 * mx.cos(mx.radians(mx.array(azim))).item(),
+            1.4,
+            2.4 * mx.sin(mx.radians(mx.array(azim))).item(),
+        ),
+        at=(0, 0, 0),
+        up=(0, 1, 0),
+        fov=45.0,
+        width=size,
+        height=size,
+    )
+    return renderer(camera, mesh, sigma=3e-3, background=(0.05, 0.05, 0.08))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--size", type=int, default=256)
+    parser.add_argument("--outdir", type=str, default="outputs")
+    args = parser.parse_args()
+
+    mesh = ico_sphere(level=3, radius=1.0)
+
+    # The exact same turntable loop drives both renderers interchangeably.
+    renderers: dict[str, Renderer] = {
+        "builtin_soft": lambda cam, m, **kw: render_mesh_soft(
+            cam, m, verts_colors=0.5 * m.verts_packed() + 0.5, **kw
+        ),
+        "custom_normals": render_normals,
+    }
+
+    for name, renderer in renderers.items():
+        out = turntable(renderer, mesh, size=args.size, azim=35.0)
+        mx.eval(out["image"])
+        path = f"{args.outdir}/extend_{name}.png"
+        save_image(path, out["image"])
+        print(f"{name:>16}: saved {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/extract_mesh.py
+++ b/examples/extract_mesh.py
@@ -1,0 +1,67 @@
+"""Extract a mesh from an implicit field with marching cubes (no data needed).
+
+Samples a smooth-union signed-distance field of two spheres on a grid, runs
+:func:`mlx3d.ops.marching_cubes` to recover a triangle mesh, saves it as OBJ,
+and renders it so you can see what came out.
+
+Usage:
+    python examples/extract_mesh.py [--res 96] [--out outputs/extracted.obj]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image, save_obj
+from mlx3d.ops import marching_cubes
+from mlx3d.renderer import render_mesh_soft
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--res", type=int, default=48)
+    parser.add_argument("--out", type=str, default="outputs/extracted_mesh.obj")
+    parser.add_argument("--render", type=str, default="outputs/extracted_mesh.png")
+    args = parser.parse_args()
+
+    # Sample an SDF on a [-1.5, 1.5]^3 grid: smooth union of two spheres.
+    n = args.res
+    lin = mx.linspace(-1.5, 1.5, n)
+    z, y, x = mx.meshgrid(lin, lin, lin, indexing="ij")
+    p = mx.stack([x, y, z], axis=-1)
+    d1 = mx.linalg.norm(p - mx.array([-0.45, 0.0, 0.0]), axis=-1) - 0.7
+    d2 = mx.linalg.norm(p - mx.array([0.45, 0.0, 0.0]), axis=-1) - 0.7
+    k = 0.3
+    sdf = -k * mx.log(mx.exp(-d1 / k) + mx.exp(-d2 / k))  # smooth min
+
+    spacing = 3.0 / (n - 1)
+    mesh = marching_cubes(
+        sdf, level=0.0, spacing=(spacing, spacing, spacing), origin=(-1.5, -1.5, -1.5)
+    )
+    print(f"Extracted {mesh.faces_packed().shape[0]} faces, {mesh.verts_packed().shape[0]} verts")
+
+    save_obj(args.out, mesh.verts_packed(), mesh.faces_packed())
+    print(f"Saved {args.out}")
+
+    camera = Camera.look_at(
+        eye=(2.6, 1.8, 2.6), at=(0, 0, 0), up=(0, 1, 0), fov=45.0, width=160, height=160
+    )
+    normals = mesh.verts_normals_packed()
+    verts_colors = 0.5 * normals + 0.5
+    out = render_mesh_soft(
+        camera, mesh, verts_colors=verts_colors, sigma=3e-3, background=(0.05, 0.05, 0.08)
+    )
+    mx.eval(out["image"])
+    save_image(args.render, out["image"])
+    print(f"Saved {args.render}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fit_gaussians.py
+++ b/examples/fit_gaussians.py
@@ -1,0 +1,106 @@
+"""Fit 3D Gaussians to a synthetic multi-view scene (no data needed).
+
+Renders ground-truth views of an analytic colored sphere, initializes a random
+Gaussian point cloud, and optimizes it with the real :class:`GaussianTrainer`
+(the same training loop used for COLMAP/Blender scenes), then renders a held-out
+view. This is the quickest way to see the splatting pipeline end to end; for
+real scenes with densification tuned for quality, use
+``train_gaussian_splatting.py``.
+
+Usage:
+    python examples/fit_gaussians.py [--iters 400]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image
+from mlx3d.losses import psnr
+from mlx3d.renderer import sample_along_rays, volume_render
+from mlx3d.splatting import GaussianModel, GaussianTrainer, TrainerConfig
+
+NEAR, FAR = 1.0, 4.0
+
+
+def _camera(azim: float, elev: float, res: int) -> Camera:
+    a, e = mx.radians(mx.array(azim)), mx.radians(mx.array(elev))
+    d = 2.8
+    eye = (
+        d * float(mx.cos(e) * mx.sin(a)),
+        d * float(mx.sin(e)),
+        d * float(mx.cos(e) * mx.cos(a)),
+    )
+    return Camera.look_at(eye=eye, at=(0, 0, 0), up=(0, 1, 0), fov=45.0, width=res, height=res)
+
+
+def _ground_truth(camera: Camera, samples: int = 96) -> mx.array:
+    """A soft glowing colored sphere, volume-rendered for multi-view consistency."""
+    o, d = camera.generate_rays()
+    h, w = o.shape[:2]
+    points, t_vals = sample_along_rays(
+        o.reshape(-1, 3), d.reshape(-1, 3), NEAR, FAR, samples, False
+    )
+    r = mx.linalg.norm(points, axis=-1)
+    density = 30.0 * mx.maximum(0.6 - mx.abs(r - 0.6), 0.0)
+    rgb = 0.5 * (points / mx.maximum(r[..., None], 1e-6)) + 0.5
+    return volume_render(density, rgb, t_vals, d.reshape(-1, 3))["rgb"].reshape(h, w, 3)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=400)
+    parser.add_argument("--res", type=int, default=64)
+    parser.add_argument("--num-gaussians", type=int, default=4000)
+    parser.add_argument("--out", type=str, default="outputs/fit_gaussians.png")
+    args = parser.parse_args()
+
+    # Training views: a ring of cameras at two elevations.
+    views = []
+    for elev in (-20.0, 20.0):
+        for azim in range(0, 360, 45):
+            cam = _camera(float(azim), elev, args.res)
+            views.append((cam, _ground_truth(cam)))
+    print(f"{len(views)} synthetic training views at {args.res}x{args.res}")
+
+    # Random initial Gaussians inside a unit ball with random colors.
+    key = mx.random.normal((args.num_gaussians, 3))
+    points = key / mx.maximum(mx.linalg.norm(key, axis=-1, keepdims=True), 1e-6)
+    points = points * mx.random.uniform(shape=(args.num_gaussians, 1)) ** (1 / 3) * 0.9
+    colors = mx.random.uniform(shape=(args.num_gaussians, 3))
+    model = GaussianModel.from_points(points, colors, sh_degree=2)
+
+    config = TrainerConfig(
+        densify_from=100,
+        densify_until=args.iters,
+        densify_every=100,
+        opacity_reset_every=10_000,
+        sh_increase_every=200,
+        white_background=False,
+    )
+    trainer = GaussianTrainer(model, config, scene_extent=1.0)
+
+    for it in range(args.iters):
+        cam, target = views[it % len(views)]
+        info = trainer.step(cam, target)
+        if it % 100 == 0 or it == args.iters - 1:
+            print(f"iter {it:4d}  loss {info['loss']:.5f}  gaussians {info['num_gaussians']}")
+
+    # Held-out view between training azimuths.
+    cam = _camera(22.5, 0.0, args.res * 2)
+    out = model.render(cam)
+    mx.eval(out["image"])
+    save_image(args.out, out["image"])
+    ref = _ground_truth(cam)
+    print(f"Held-out PSNR: {float(psnr(out['image'], ref)):.2f} dB  ->  saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fit_nerf.py
+++ b/examples/fit_nerf.py
@@ -1,0 +1,120 @@
+"""Train a small NeRF on a synthetic scene generated in-process (no data needed).
+
+Builds ground-truth views by volume-rendering an analytic glowing sphere from
+six cameras, then fits a compact NeRF to them by optimizing random ray batches
+with the volume-rendering loss, and finally renders a held-out view. This
+exercises the full NeRF path — the ``NeRF`` MLP, ``render_rays``, and the
+volume renderer — without any dataset download. To train on real
+NeRF-synthetic scenes, see ``train_nerf.py``.
+
+Usage:
+    python examples/fit_nerf.py [--iters 600] [--res 48]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image
+from mlx3d.nn import NeRF, render_rays
+from mlx3d.renderer import sample_along_rays, volume_render
+
+NEAR, FAR = 1.0, 4.0
+
+
+def _camera(azim: float, res: int) -> Camera:
+    a = mx.radians(mx.array(azim))
+    return Camera.look_at(
+        eye=(2.8 * float(mx.sin(a)), 1.0, 2.8 * float(mx.cos(a))),
+        at=(0, 0, 0),
+        up=(0, 1, 0),
+        fov=45.0,
+        width=res,
+        height=res,
+    )
+
+
+def _analytic_field(points: mx.array) -> tuple[mx.array, mx.array]:
+    """Ground-truth radiance field: a soft glowing colored sphere."""
+    r = mx.linalg.norm(points, axis=-1)
+    density = 30.0 * mx.maximum(0.6 - mx.abs(r - 0.6), 0.0)
+    rgb = 0.5 * (points / mx.maximum(r[..., None], 1e-6)) + 0.5
+    return density, rgb
+
+
+def _ground_truth(camera: Camera, samples: int = 96) -> mx.array:
+    o, d = camera.generate_rays()
+    h, w = o.shape[:2]
+    points, t_vals = sample_along_rays(
+        o.reshape(-1, 3), d.reshape(-1, 3), NEAR, FAR, samples, stratified=False
+    )
+    density, rgb = _analytic_field(points)
+    out = volume_render(density, rgb, t_vals, d.reshape(-1, 3))
+    return out["rgb"].reshape(h, w, 3)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=600)
+    parser.add_argument("--res", type=int, default=48)
+    parser.add_argument("--batch-rays", type=int, default=1024)
+    parser.add_argument("--out", type=str, default="outputs/fit_nerf.png")
+    args = parser.parse_args()
+
+    # Flatten all training rays + their ground-truth colors.
+    all_o, all_d, all_c = [], [], []
+    for azim in (0.0, 60.0, 120.0, 180.0, 240.0, 300.0):
+        cam = _camera(azim, args.res)
+        o, d = cam.generate_rays()
+        all_o.append(o.reshape(-1, 3))
+        all_d.append(d.reshape(-1, 3))
+        all_c.append(_ground_truth(cam).reshape(-1, 3))
+    origins = mx.concatenate(all_o)
+    directions = mx.concatenate(all_d)
+    targets = mx.concatenate(all_c)
+    n_rays = origins.shape[0]
+
+    model = NeRF(pos_freqs=6, dir_freqs=4, hidden_dim=64, num_layers=4, skip_layer=2)
+    optimizer = optim.Adam(learning_rate=1e-3)
+
+    def loss_fn(model, o, d, c):
+        out = render_rays(model, o, d, NEAR, FAR, num_coarse=64)
+        return mx.mean((out["rgb"] - c) ** 2)
+
+    loss_and_grad = nn.value_and_grad(model, loss_fn)
+    for it in range(args.iters):
+        idx = mx.random.randint(0, n_rays, shape=(args.batch_rays,))
+        loss, grads = loss_and_grad(model, origins[idx], directions[idx], targets[idx])
+        optimizer.update(model, grads)
+        mx.eval(model.parameters(), optimizer.state)
+        if it % 150 == 0 or it == args.iters - 1:
+            print(f"iter {it:4d}  loss {float(loss):.5f}")
+
+    # Render a held-out view (azimuth between training cameras), in ray chunks.
+    cam = _camera(30.0, args.res * 2)
+    o, d = cam.generate_rays()
+    h, w = o.shape[:2]
+    o, d = o.reshape(-1, 3), d.reshape(-1, 3)
+    chunks = [
+        render_rays(
+            model, o[s : s + 4096], d[s : s + 4096], NEAR, FAR, num_coarse=64, stratified=False
+        )["rgb"]
+        for s in range(0, o.shape[0], 4096)
+    ]
+    image = mx.concatenate(chunks).reshape(h, w, 3)
+    mx.eval(image)
+    save_image(args.out, image)
+    print(f"Saved held-out render to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/raytrace_volume.py
+++ b/examples/raytrace_volume.py
@@ -1,0 +1,74 @@
+"""Ray-trace an analytic volume with the NeRF compositing rule (no data, no training).
+
+Casts one ray per pixel from a camera, samples an analytic radiance field (a
+soft glowing colored sphere), and composites it with
+:func:`mlx3d.renderer.volume_render` — the exact quadrature a NeRF uses, here
+driven by a closed-form field instead of an MLP. A good sanity check that the
+camera ray generation and volume renderer agree.
+
+Usage:
+    python examples/raytrace_volume.py [--out outputs/volume.png] [--size 256]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image
+from mlx3d.renderer import sample_along_rays, volume_render
+
+
+def radiance_field(points: mx.array) -> tuple[mx.array, mx.array]:
+    """Analytic density + RGB for a soft colored sphere of radius ~0.6.
+
+    Returns ``(density, rgb)`` with shapes ``(..., )`` and ``(..., 3)``.
+    """
+    r = mx.linalg.norm(points, axis=-1)
+    # Dense near the surface, fading smoothly outward.
+    density = 30.0 * mx.maximum(0.6 - mx.abs(r - 0.6), 0.0)
+    # Color by direction on the sphere -> a smooth RGB field.
+    rgb = 0.5 * (points / mx.maximum(r[..., None], 1e-6)) + 0.5
+    return density, rgb
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=str, default="outputs/volume_render.png")
+    parser.add_argument("--size", type=int, default=256)
+    parser.add_argument("--samples", type=int, default=96)
+    args = parser.parse_args()
+
+    camera = Camera.look_at(
+        eye=(1.8, 1.2, 1.8),
+        at=(0, 0, 0),
+        up=(0, 1, 0),
+        fov=45.0,
+        width=args.size,
+        height=args.size,
+    )
+    origins, directions = camera.generate_rays()  # (H, W, 3) each
+    h, w = args.size, args.size
+    origins = origins.reshape(-1, 3)
+    directions = directions.reshape(-1, 3)
+
+    points, t_vals = sample_along_rays(
+        origins, directions, near=1.0, far=4.0, num_samples=args.samples, stratified=False
+    )
+    density, rgb = radiance_field(points)
+    out = volume_render(density, rgb, t_vals, directions, white_background=True)
+
+    image = out["rgb"].reshape(h, w, 3)
+    mx.eval(image)
+    save_image(args.out, image)
+    print(f"Saved {args.out}  (mean opacity: {float(out['acc'].mean()):.3f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/render_mesh.py
+++ b/examples/render_mesh.py
@@ -1,0 +1,58 @@
+"""Rasterize a mesh with the differentiable soft renderer (no data needed).
+
+Builds an icosphere, colors its vertices by position, and renders it from a
+look-at camera with :func:`mlx3d.renderer.render_mesh_soft`. The same call is
+differentiable w.r.t. vertices, colors, and textures.
+
+Usage:
+    python examples/render_mesh.py [--out outputs/mesh.png] [--size 256]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image
+from mlx3d.renderer import render_mesh_soft
+from mlx3d.utils import ico_sphere
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=str, default="outputs/mesh_render.png")
+    parser.add_argument("--size", type=int, default=256)
+    args = parser.parse_args()
+
+    mesh = ico_sphere(level=3, radius=1.0)
+    verts = mesh.verts_packed()
+    # Per-vertex color from position: maps the unit sphere to a smooth RGB field.
+    verts_colors = (
+        0.5 * (verts / mx.maximum(mx.linalg.norm(verts, axis=-1, keepdims=True), 1e-6)) + 0.5
+    )
+
+    camera = Camera.look_at(
+        eye=(2.2, 1.6, 2.2),
+        at=(0, 0, 0),
+        up=(0, 1, 0),
+        fov=45.0,
+        width=args.size,
+        height=args.size,
+    )
+
+    out = render_mesh_soft(
+        camera, mesh, verts_colors=verts_colors, sigma=3e-3, background=(0.05, 0.05, 0.08)
+    )
+    mx.eval(out["image"])
+    save_image(args.out, out["image"])
+    print(f"Saved {args.out}  (alpha coverage: {float(out['alpha'].mean()):.3f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train_gaussian_splatting.py
+++ b/examples/train_gaussian_splatting.py
@@ -92,77 +92,183 @@ def main() -> None:
     parser.add_argument("--data", type=str, required=True)
     parser.add_argument("--format", choices=["colmap", "blender"], default="colmap")
     parser.add_argument("--iters", type=int, default=7000)
-    parser.add_argument("--seed", type=int, default=0,
-                        help="random seed for reproducible init/order; <0 disables seeding")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="random seed for reproducible init/order; <0 disables seeding",
+    )
     parser.add_argument("--downscale", type=int, default=1)
     parser.add_argument("--sh-degree", type=int, default=3)
-    parser.add_argument("--init-points", type=int, default=30000,
-                        help="random init size for blender scenes (no SfM points)")
+    parser.add_argument(
+        "--init-points",
+        type=int,
+        default=30000,
+        help="random init size for blender scenes (no SfM points)",
+    )
     parser.add_argument("--out", type=str, default="outputs/gs")
-    parser.add_argument("--low-mem", action="store_true",
-                        help="low-memory mode for 8-16 GB machines: uint8 image "
-                             "cache, capped Gaussian count, capped MLX buffer cache")
-    parser.add_argument("--image-cache", choices=["ram", "uint8", "disk"], default=None,
-                        help="image storage policy (default: ram, or uint8 with --low-mem)")
-    parser.add_argument("--max-gaussians", type=int, default=None,
-                        help="cap on the Gaussian count (default: 1.2M with --low-mem)")
-    parser.add_argument("--scale-init-max-ref", type=int, default=None,
-                        help="max reference points for initial scale KNN "
-                             "(default: 10000)")
-    parser.add_argument("--scale-init-chunk-size", type=int, default=None,
-                        help="query chunk size for initial scale KNN "
-                             "(default: 1024; fallback path only)")
-    parser.add_argument("--init-scale-max-frac", type=float, default=0.01,
-                        help="cap initial Gaussian scale as this fraction of scene extent; "
-                             "<=0 disables the cap")
-    parser.add_argument("--position-lr-final", type=float, default=1.6e-6,
-                        help="final unscaled xyz learning rate for exponential decay")
-    parser.add_argument("--position-lr-max-steps", type=int, default=30_000,
-                        help="steps over which xyz learning rate decays")
-    parser.add_argument("--method", choices=["vanilla", "mcmc", "2dgs"], default="vanilla",
-                        help="training strategy; vanilla 3DGS is the default")
-    parser.add_argument("--densify-from", type=int, default=500,
-                        help="first iteration that accumulates densification stats")
-    parser.add_argument("--densify-until", type=int, default=None,
-                        help="last iteration for densification (default: iters // 2)")
-    parser.add_argument("--densify-every", type=int, default=100,
-                        help="run clone/split/prune every N iterations")
-    parser.add_argument("--densify-grad-threshold", type=float, default=0.0002,
-                        help="screen-space gradient threshold for clone/split")
-    parser.add_argument("--mcmc-relocate-frac", type=float, default=0.02,
-                        help="MCMC mode: max fraction of Gaussians relocated per density event")
-    parser.add_argument("--mcmc-min-opacity", type=float, default=0.01,
-                        help="MCMC mode: opacity threshold for relocation targets")
-    parser.add_argument("--mcmc-jitter-scale", type=float, default=0.25,
-                        help="MCMC mode: relocation jitter as a multiple of source scale")
-    parser.add_argument("--mcmc-noise-scale", type=float, default=0.01,
-                        help="MCMC mode: per-step SGLD-like xyz noise scale")
-    parser.add_argument("--2d-thickness", dest="two_d_thickness", type=float, default=1e-4,
-                        help="2DGS mode: local-normal thickness as a fraction of scene extent")
-    parser.add_argument("--cache-limit-gb", type=float, default=2.0,
-                        help="MLX buffer-cache cap used with --low-mem")
-    parser.add_argument("--log-every", type=int, default=10,
-                        help="print fallback/log event frequency")
-    parser.add_argument("--save-every", type=int, default=1000,
-                        help="save render/checkpoint frequency; <=0 disables periodic saves")
-    parser.add_argument("--eval-views", type=int, default=1,
-                        help="number of deterministic training views to average for save-time PSNR")
-    parser.add_argument("--no-progress", action="store_true",
-                        help="disable tqdm progress bar even when tqdm is installed")
-    parser.add_argument("--viewer", action="store_true",
-                        help="start a live browser viewer while training")
+    parser.add_argument(
+        "--low-mem",
+        action="store_true",
+        help="low-memory mode for 8-16 GB machines: uint8 image "
+        "cache, capped Gaussian count, capped MLX buffer cache",
+    )
+    parser.add_argument(
+        "--image-cache",
+        choices=["ram", "uint8", "disk"],
+        default=None,
+        help="image storage policy (default: ram, or uint8 with --low-mem)",
+    )
+    parser.add_argument(
+        "--max-gaussians",
+        type=int,
+        default=None,
+        help="cap on the Gaussian count (default: 1.2M with --low-mem)",
+    )
+    parser.add_argument(
+        "--scale-init-max-ref",
+        type=int,
+        default=None,
+        help="max reference points for initial scale KNN (default: 10000)",
+    )
+    parser.add_argument(
+        "--scale-init-chunk-size",
+        type=int,
+        default=None,
+        help="query chunk size for initial scale KNN (default: 1024; fallback path only)",
+    )
+    parser.add_argument(
+        "--init-scale-max-frac",
+        type=float,
+        default=0.01,
+        help="cap initial Gaussian scale as this fraction of scene extent; <=0 disables the cap",
+    )
+    parser.add_argument(
+        "--position-lr-final",
+        type=float,
+        default=1.6e-6,
+        help="final unscaled xyz learning rate for exponential decay",
+    )
+    parser.add_argument(
+        "--position-lr-max-steps",
+        type=int,
+        default=30_000,
+        help="steps over which xyz learning rate decays",
+    )
+    parser.add_argument(
+        "--method",
+        choices=["vanilla", "mcmc", "2dgs"],
+        default="vanilla",
+        help="training strategy; vanilla 3DGS is the default",
+    )
+    parser.add_argument(
+        "--densify-from",
+        type=int,
+        default=500,
+        help="first iteration that accumulates densification stats",
+    )
+    parser.add_argument(
+        "--densify-until",
+        type=int,
+        default=None,
+        help="last iteration for densification (default: iters // 2)",
+    )
+    parser.add_argument(
+        "--densify-every", type=int, default=100, help="run clone/split/prune every N iterations"
+    )
+    parser.add_argument(
+        "--densify-grad-threshold",
+        type=float,
+        default=0.0002,
+        help="screen-space gradient threshold for clone/split",
+    )
+    parser.add_argument(
+        "--mcmc-relocate-frac",
+        type=float,
+        default=0.02,
+        help="MCMC mode: max fraction of Gaussians relocated per density event",
+    )
+    parser.add_argument(
+        "--mcmc-min-opacity",
+        type=float,
+        default=0.01,
+        help="MCMC mode: opacity threshold for relocation targets",
+    )
+    parser.add_argument(
+        "--mcmc-jitter-scale",
+        type=float,
+        default=0.25,
+        help="MCMC mode: relocation jitter as a multiple of source scale",
+    )
+    parser.add_argument(
+        "--mcmc-noise-scale",
+        type=float,
+        default=0.01,
+        help="MCMC mode: per-step SGLD-like xyz noise scale",
+    )
+    parser.add_argument(
+        "--2d-thickness",
+        dest="two_d_thickness",
+        type=float,
+        default=1e-4,
+        help="2DGS mode: local-normal thickness as a fraction of scene extent",
+    )
+    parser.add_argument(
+        "--cache-limit-gb", type=float, default=2.0, help="MLX buffer-cache cap used with --low-mem"
+    )
+    parser.add_argument(
+        "--log-every", type=int, default=10, help="print fallback/log event frequency"
+    )
+    parser.add_argument(
+        "--save-every",
+        type=int,
+        default=1000,
+        help="save render/checkpoint frequency; <=0 disables periodic saves",
+    )
+    parser.add_argument(
+        "--eval-views",
+        type=int,
+        default=1,
+        help="number of deterministic training views to average for save-time PSNR",
+    )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="disable tqdm progress bar even when tqdm is installed",
+    )
+    parser.add_argument(
+        "--viewer", action="store_true", help="start a live browser viewer while training"
+    )
     parser.add_argument("--viewer-host", type=str, default="127.0.0.1")
     parser.add_argument("--viewer-port", type=int, default=8090)
-    parser.add_argument("--viewer-no-browser", action="store_true",
-                        help="start the live viewer without opening a browser")
-    parser.add_argument("--viewer-update-every", type=int, default=25,
-                        help="publish a fresh live-viewer snapshot every N steps")
-    parser.add_argument("--viewer-max-scale", type=float, default=0.5,
-                        help="max browser render scale for live preview")
-    parser.add_argument("--viewer-poll-ms", type=int, default=750,
-                        help="browser metadata polling interval for live preview")
-    parser.add_argument("--viewer-keep-open", action="store_true",
-                        help="keep the process alive after training so the viewer stays open")
+    parser.add_argument(
+        "--viewer-no-browser",
+        action="store_true",
+        help="start the live viewer without opening a browser",
+    )
+    parser.add_argument(
+        "--viewer-update-every",
+        type=int,
+        default=25,
+        help="publish a fresh live-viewer snapshot every N steps",
+    )
+    parser.add_argument(
+        "--viewer-max-scale",
+        type=float,
+        default=0.5,
+        help="max browser render scale for live preview",
+    )
+    parser.add_argument(
+        "--viewer-poll-ms",
+        type=int,
+        default=750,
+        help="browser metadata polling interval for live preview",
+    )
+    parser.add_argument(
+        "--viewer-keep-open",
+        action="store_true",
+        help="keep the process alive after training so the viewer stays open",
+    )
     args = parser.parse_args()
     if args.seed >= 0:
         np.random.seed(args.seed)
@@ -206,8 +312,10 @@ def main() -> None:
             "Check the COLMAP camera metadata, image files, and --downscale."
         )
     resident_gb = getattr(ds.images, "nbytes_resident", 0) / float(1 << 30)
-    print(f"{len(ds)} views, init with {init_points.shape[0]} points, "
-          f"extent {scene_extent:.2f}", flush=True)
+    print(
+        f"{len(ds)} views, init with {init_points.shape[0]} points, extent {scene_extent:.2f}",
+        flush=True,
+    )
     print(
         f"Training resolution {cam0.width}x{cam0.height}, image cache {image_cache} "
         f"({resident_gb:.2f}G resident), dataset loaded in {time.perf_counter() - t0:.1f}s",

--- a/examples/train_nerf.py
+++ b/examples/train_nerf.py
@@ -62,8 +62,13 @@ def main() -> None:
 
     def loss_fn(model, o, d, c):
         out = render_rays(
-            model, o, d, args.near, args.far,
-            num_coarse=args.num_coarse, num_fine=args.num_fine,
+            model,
+            o,
+            d,
+            args.near,
+            args.far,
+            num_coarse=args.num_coarse,
+            num_fine=args.num_fine,
             white_background=True,
         )
         loss = ((out["rgb"] - c) ** 2).mean()
@@ -88,7 +93,9 @@ def main() -> None:
         mx.eval(model.parameters(), optimizer.state)
 
         if it % 100 == 0:
-            print(f"iter {it:6d}  loss {float(loss):.5f}  psnr {-10*np.log10(float(loss)/2):.2f}")
+            print(
+                f"iter {it:6d}  loss {float(loss):.5f}  psnr {-10 * np.log10(float(loss) / 2):.2f}"
+            )
 
         if it % 1000 == 0:
             render_view(model, train.cameras[0], args, os.path.join(args.out, "nerf_view.png"))
@@ -102,9 +109,15 @@ def render_view(model, cam, args, path, chunk=4096):
     pixels = []
     for s in range(0, o.shape[0], chunk):
         out = render_rays(
-            model, o[s : s + chunk], d[s : s + chunk], args.near, args.far,
-            num_coarse=args.num_coarse, num_fine=args.num_fine,
-            stratified=False, white_background=True,
+            model,
+            o[s : s + chunk],
+            d[s : s + chunk],
+            args.near,
+            args.far,
+            num_coarse=args.num_coarse,
+            num_fine=args.num_fine,
+            stratified=False,
+            white_background=True,
         )
         pixels.append(out["rgb"])
         mx.eval(pixels[-1])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - "NeRF: Neural Radiance Fields": tutorials/nerf.md
       - Hash-Grid NeRF Encodings: tutorials/hashgrid_nerf.md
       - Gaussian Splatting: tutorials/gaussian_splatting.md
+      - Extending MLX3D: tutorials/extending.md
   - API Reference:
       - Structures: api/structures.md
       - Cameras: api/cameras.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ extend-select = ["I"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "-q"
+addopts = "-q --strict-markers"
 testpaths = ["tests"]
 pythonpath = ["src"]
+markers = [
+  "smoke: fast import/public-API checks that the package is wired together",
+  "unit: focused tests of a single function or class",
+  "behavior: end-to-end gradient/optimization behavior across modules",
+  "data: dataset loaders against synthetic in-process fixtures",
+]

--- a/src/mlx3d/io/__init__.py
+++ b/src/mlx3d/io/__init__.py
@@ -1,4 +1,14 @@
+from .image_io import load_image, save_image
 from .obj_io import ObjData, load_obj, save_obj
 from .ply_io import PlyData, load_ply, save_ply
 
-__all__ = ["ObjData", "PlyData", "load_obj", "load_ply", "save_obj", "save_ply"]
+__all__ = [
+    "ObjData",
+    "PlyData",
+    "load_image",
+    "load_obj",
+    "load_ply",
+    "save_image",
+    "save_obj",
+    "save_ply",
+]

--- a/src/mlx3d/io/image_io.py
+++ b/src/mlx3d/io/image_io.py
@@ -1,0 +1,59 @@
+"""Reading and writing images as MLX arrays.
+
+These helpers bridge MLX float images (``(H, W, 3)`` or ``(H, W)`` in ``[0, 1]``)
+and on-disk PNG/JPEG files, so any renderer output can be saved or loaded with a
+single call::
+
+    out = render_mesh_soft(camera, mesh)
+    save_image("render.png", out["image"])
+"""
+
+from __future__ import annotations
+
+import os
+
+import mlx.core as mx
+import numpy as np
+from PIL import Image
+
+__all__ = ["load_image", "save_image"]
+
+
+def load_image(path: str, *, normalize: bool = True) -> mx.array:
+    """Load an image from disk as an MLX array.
+
+    Args:
+        path: Path to a PNG/JPEG/... file readable by Pillow.
+        normalize: If ``True`` (default), return float32 in ``[0, 1]``;
+            otherwise return the raw ``uint8`` values.
+
+    Returns:
+        ``(H, W, 3)`` for RGB images (alpha is dropped), or ``(H, W)`` for
+        single-channel images.
+    """
+    img = Image.open(path)
+    if img.mode in ("RGBA", "P", "LA"):
+        img = img.convert("RGB")
+    arr = np.asarray(img)
+    if not normalize:
+        return mx.array(arr)
+    return mx.array(arr.astype(np.float32) / 255.0)
+
+
+def save_image(path: str, image: mx.array | np.ndarray) -> None:
+    """Save an MLX (or NumPy) image to disk.
+
+    Accepts float images in ``[0, 1]`` (clipped) or ``uint8`` images. Grayscale
+    ``(H, W)``, RGB ``(H, W, 3)`` and RGBA ``(H, W, 4)`` are all supported.
+    Parent directories are created automatically.
+
+    Args:
+        path: Destination file path; the format is inferred from the extension.
+        image: The image to save.
+    """
+    arr = np.asarray(image)
+    if arr.dtype != np.uint8:
+        arr = (np.clip(arr, 0.0, 1.0) * 255.0).round().astype(np.uint8)
+    parent = os.path.dirname(os.path.abspath(path))
+    os.makedirs(parent, exist_ok=True)
+    Image.fromarray(arr).save(path)

--- a/src/mlx3d/renderer/__init__.py
+++ b/src/mlx3d/renderer/__init__.py
@@ -1,8 +1,11 @@
 from .mesh import render_mesh_soft, sample_texture
 from .points import render_points
+from .protocols import Renderer, RenderOutput
 from .rays import sample_along_rays, sample_pdf, volume_render
 
 __all__ = [
+    "RenderOutput",
+    "Renderer",
     "render_mesh_soft",
     "render_points",
     "sample_along_rays",

--- a/src/mlx3d/renderer/mesh.py
+++ b/src/mlx3d/renderer/mesh.py
@@ -175,8 +175,14 @@ def render_mesh_soft(
         in_front = mx.all(tz > camera.znear, axis=-1)[:, None, None]
         coverage = coverage * valid_area * in_front
 
+        # Barycentric coords go outside [0, 1] for pixels off the triangle, so
+        # ``z_face`` there can fall below ``znear`` and make ``inv_depth`` blow
+        # up. Clamp the exponent at 0 (the globally nearest face gets weight 1):
+        # this both matches the soft z-buffer semantics and avoids the
+        # ``coverage(=0) * exp(=inf) = NaN`` that would otherwise appear where a
+        # distant face projects far from the pixel.
         inv_depth = 1.0 / mx.maximum(z_face, camera.znear)
-        depth_w = mx.exp(depth_temperature * (inv_depth - max_inv_depth))
+        depth_w = mx.exp(mx.minimum(depth_temperature * (inv_depth - max_inv_depth), 0.0))
         weights = coverage * depth_w  # (C, H, W)
 
         if texture is not None:

--- a/src/mlx3d/renderer/protocols.py
+++ b/src/mlx3d/renderer/protocols.py
@@ -1,0 +1,62 @@
+"""The renderer convention that ties MLX3D's pipeline together.
+
+Every image-space renderer in MLX3D — :func:`render_mesh_soft`,
+:func:`render_points`, :meth:`GaussianModel.render` — follows the same simple
+contract: it is a callable that takes a :class:`~mlx3d.cameras.Camera` (plus
+whatever scene data it needs) and returns a :class:`RenderOutput` dict.
+
+This is intentionally a *convention*, not a base class. To add your own
+renderer — a toon shader, a wireframe pass, a custom rasterizer — you just
+write a function with the same shape and it drops straight into the rest of the
+pipeline (saving, the viewer, side-by-side comparisons)::
+
+    def render_normals(camera, mesh) -> RenderOutput:
+        ...
+        return {"image": rgb, "alpha": alpha, "depth": depth}
+
+The :class:`Renderer` protocol exists only to document and type-check that
+shape; you never need to inherit from anything.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypedDict, runtime_checkable
+
+import mlx.core as mx
+
+from ..cameras import Camera
+
+__all__ = ["RenderOutput", "Renderer"]
+
+
+class RenderOutput(TypedDict, total=False):
+    """The dict every image-space renderer returns.
+
+    Keys are optional so depth-only or alpha-only passes are still valid
+    outputs, but RGB renderers populate all three:
+
+    - ``image``: ``(H, W, 3)`` RGB in ``[0, 1]``.
+    - ``alpha``: ``(H, W)`` coverage / opacity in ``[0, 1]``.
+    - ``depth``: ``(H, W)`` expected depth in world units.
+
+    Renderers may attach extra keys (e.g. ``means2d`` for splatting); consumers
+    should read by key rather than assume an exact set.
+    """
+
+    image: mx.array
+    alpha: mx.array
+    depth: mx.array
+
+
+@runtime_checkable
+class Renderer(Protocol):
+    """Anything callable as ``renderer(camera, *scene) -> RenderOutput``.
+
+    Use it purely as a type hint for code that accepts a pluggable renderer::
+
+        def turntable(renderer: Renderer, cameras, scene): ...
+
+    Both library functions and your own closures satisfy it without subclassing.
+    """
+
+    def __call__(self, camera: Camera, *args: object, **kwargs: object) -> RenderOutput: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Shared pytest configuration.
+
+Tests are sliced into the marker groups declared in ``pyproject.toml`` so CI can
+run them selectively (``pytest -m smoke``, ``-m "unit or data"``, ...). Rather
+than sprinkle ``pytestmark`` across every file, categories are assigned here by
+module name; anything not listed is a focused unit test.
+"""
+
+import pytest
+
+_CATEGORY_BY_MODULE = {
+    "test_import": "smoke",
+    "test_smoke": "smoke",
+    "test_behavior": "behavior",
+    "test_datasets": "data",
+}
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        category = _CATEGORY_BY_MODULE.get(item.path.stem, "unit")
+        item.add_marker(getattr(pytest.mark, category))

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,0 +1,154 @@
+"""Behavior tests: gradients flow and optimization reduces loss end to end.
+
+These span multiple modules (cameras + renderers + losses + optimizers) and act
+as integration coverage for the differentiable pipeline.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+
+from mlx3d.cameras import Camera
+from mlx3d.nn import NeRF, render_rays
+from mlx3d.ops import marching_cubes
+from mlx3d.renderer import render_mesh_soft, sample_along_rays, volume_render
+from mlx3d.splatting import GaussianModel, GaussianTrainer, TrainerConfig
+from mlx3d.utils import ico_sphere
+
+
+def test_multiface_mesh_renders_without_nan():
+    """Regression: a closed mesh (many faces) must not produce NaNs.
+
+    Faces far from a pixel get out-of-triangle barycentric coords, which can
+    push ``z_face`` below ``znear`` and overflow the depth weighting; the
+    rasterizer must stay finite and produce real coverage.
+    """
+    mesh = ico_sphere(level=3, radius=1.0)
+    verts = mesh.verts_packed()
+    colors = 0.5 * verts / mx.maximum(mx.linalg.norm(verts, axis=-1, keepdims=True), 1e-6) + 0.5
+    cam = Camera.look_at(eye=(2.2, 1.6, 2.2), at=(0, 0, 0), fov=45.0, width=64, height=64)
+
+    out = render_mesh_soft(cam, mesh, verts_colors=colors, sigma=3e-3, background=0.0)
+    mx.eval(out["image"], out["alpha"], out["depth"])
+    for key in ("image", "alpha", "depth"):
+        assert not bool(mx.isnan(out[key]).any()), f"NaN in {key}"
+    assert float(out["alpha"].mean()) > 0.05  # the sphere is actually visible
+
+
+def test_mesh_color_optimization_reduces_loss():
+    cam = Camera.look_at(eye=(0, 0, -3.0), at=(0, 0, 0), fov=60.0, width=32, height=32)
+    verts = mx.array([[-0.7, -0.6, 0.0], [0.7, -0.6, 0.0], [0.0, 0.7, 0.0]])
+    faces = mx.array([[0, 1, 2]], dtype=mx.int32)
+    # Target is a real render with a known color, so it is exactly reachable.
+    target = render_mesh_soft(
+        cam, verts, faces, face_colors=mx.array([[0.2, 0.8, 0.3]]), sigma=0.02
+    )["image"]
+
+    opt = optim.Adam(learning_rate=0.1)
+
+    def loss_fn(color):
+        out = render_mesh_soft(cam, verts, faces, face_colors=color, sigma=0.02)
+        return mx.mean((out["image"] - target) ** 2)
+
+    losses = []
+    color = mx.array([[0.5, 0.5, 0.5]])
+    lg = mx.value_and_grad(loss_fn)
+    for _ in range(20):
+        loss, grad = lg(color)
+        color = opt.apply_gradients({"c": grad}, {"c": color})["c"]
+        mx.eval(color)
+        losses.append(float(loss))
+    assert losses[-1] < 0.2 * losses[0]
+
+
+def test_volume_render_color_fit_reduces_loss():
+    """Optimizing per-sample colors through the volume renderer fits a target."""
+    rays, samples = 64, 16
+    densities = mx.ones((rays, samples)) * 5.0  # high opacity -> strong color signal
+    t_vals = mx.broadcast_to(mx.linspace(0.0, 1.0, samples)[None], (rays, samples))
+    target = mx.broadcast_to(mx.array([0.9, 0.1, 0.4])[None], (rays, 3))
+
+    colors = mx.zeros((rays, samples, 3)) + 0.5
+    opt = optim.Adam(learning_rate=0.2)
+
+    def loss_fn(colors):
+        out = volume_render(densities, colors, t_vals)
+        return mx.mean((out["rgb"] - target) ** 2)
+
+    lg = mx.value_and_grad(loss_fn)
+    first = last = None
+    for i in range(60):
+        loss, grad = lg(colors)
+        colors = opt.apply_gradients({"c": grad}, {"c": colors})["c"]
+        mx.eval(colors)
+        if i == 0:
+            first = float(loss)
+        last = float(loss)
+    assert last < 0.2 * first
+
+
+def test_nerf_render_rays_trains_a_few_steps():
+    """A tiny NeRF reduces its loss on synthetic volume-rendered rays."""
+    mx.random.seed(0)
+    near, far = 1.0, 4.0
+    cam = Camera.look_at(eye=(0, 0, 2.8), at=(0, 0, 0), fov=45.0, width=24, height=24)
+    o, d = cam.generate_rays()
+    o, d = o.reshape(-1, 3), d.reshape(-1, 3)
+    pts, t = sample_along_rays(o, d, near, far, 48, stratified=False)
+    r = mx.linalg.norm(pts, axis=-1)
+    density = 30.0 * mx.maximum(0.6 - mx.abs(r - 0.6), 0.0)
+    rgb = 0.5 * pts / mx.maximum(r[..., None], 1e-6) + 0.5
+    target = volume_render(density, rgb, t, d)["rgb"]
+
+    model = NeRF(pos_freqs=4, dir_freqs=2, hidden_dim=32, num_layers=3, skip_layer=1)
+    opt = optim.Adam(learning_rate=2e-3)
+
+    def loss_fn(model):
+        out = render_rays(model, o, d, near, far, num_coarse=32)
+        return mx.mean((out["rgb"] - target) ** 2)
+
+    lg = nn.value_and_grad(model, loss_fn)
+    first = float(loss_fn(model))
+    for _ in range(40):
+        loss, grads = lg(model)
+        opt.update(model, grads)
+        mx.eval(model.parameters(), opt.state)
+    assert float(loss) < 0.8 * first
+    assert not bool(mx.isnan(loss))
+
+
+def test_gaussian_trainer_step_reduces_loss():
+    mx.random.seed(0)
+    cam = Camera.look_at(eye=(0, 0, 2.8), at=(0, 0, 0), fov=45.0, width=32, height=32)
+    o, d = cam.generate_rays()
+    o, d = o.reshape(-1, 3), d.reshape(-1, 3)
+    pts, t = sample_along_rays(o, d, 1.0, 4.0, 48, stratified=False)
+    r = mx.linalg.norm(pts, axis=-1)
+    density = 30.0 * mx.maximum(0.6 - mx.abs(r - 0.6), 0.0)
+    rgb = 0.5 * pts / mx.maximum(r[..., None], 1e-6) + 0.5
+    target = volume_render(density, rgb, t, d)["rgb"].reshape(32, 32, 3)
+
+    key = mx.random.normal((500, 3))
+    points = key / mx.maximum(mx.linalg.norm(key, axis=-1, keepdims=True), 1e-6) * 0.6
+    model = GaussianModel.from_points(points, mx.random.uniform(shape=(500, 3)), sh_degree=0)
+    trainer = GaussianTrainer(model, TrainerConfig(densify_from=10_000), scene_extent=1.0)
+
+    first = trainer.step(cam, target)["loss"]
+    for _ in range(20):
+        info = trainer.step(cam, target)
+    assert info["loss"] < first
+
+
+def test_marching_cubes_recovers_sphere_extent():
+    n = 32
+    lin = mx.linspace(-1.5, 1.5, n)
+    z, y, x = mx.meshgrid(lin, lin, lin, indexing="ij")
+    sdf = mx.sqrt(x**2 + y**2 + z**2) - 1.0
+    spacing = 3.0 / (n - 1)
+    mesh = marching_cubes(sdf, level=0.0, spacing=(spacing,) * 3, origin=(-1.5, -1.5, -1.5))
+    verts = mesh.verts_packed()
+    assert verts.shape[0] > 0
+    radii = mx.linalg.norm(verts, axis=-1)
+    # All surface vertices lie ~on the unit sphere.
+    assert abs(float(radii.mean()) - 1.0) < 0.1
+    assert float(radii.max()) < 1.2

--- a/tests/test_image_io.py
+++ b/tests/test_image_io.py
@@ -1,0 +1,46 @@
+"""Unit tests for image loading and saving."""
+
+import mlx.core as mx
+import numpy as np
+
+from mlx3d.io import load_image, save_image
+
+
+def test_save_load_roundtrip_rgb(tmp_path):
+    img = mx.random.uniform(shape=(12, 16, 3))
+    path = tmp_path / "nested" / "img.png"  # parent dirs auto-created
+    save_image(str(path), img)
+    assert path.exists()
+
+    back = load_image(str(path))
+    assert back.shape == (12, 16, 3)
+    assert back.dtype == mx.float32
+    # PNG is lossless; values match to within 8-bit quantization.
+    np.testing.assert_allclose(np.array(back), np.array(img), atol=1.0 / 255 + 1e-4)
+
+
+def test_save_clips_out_of_range(tmp_path):
+    img = mx.array([[[-1.0, 0.5, 2.0]]])  # below 0 and above 1
+    path = tmp_path / "clip.png"
+    save_image(str(path), img)
+    back = load_image(str(path))
+    np.testing.assert_allclose(np.array(back[0, 0]), [0.0, 0.5, 1.0], atol=1.0 / 255 + 1e-4)
+
+
+def test_load_without_normalize_returns_uint8(tmp_path):
+    img = mx.zeros((4, 4, 3)) + 0.5
+    path = tmp_path / "u8.png"
+    save_image(str(path), img)
+    raw = load_image(str(path), normalize=False)
+    assert raw.dtype == mx.uint8
+    assert int(raw.max()) <= 255 and int(raw.min()) >= 0
+
+
+def test_save_grayscale(tmp_path):
+    img = mx.broadcast_to(mx.linspace(0.0, 1.0, 8)[None, :], (8, 8))
+    path = tmp_path / "gray.png"
+    save_image(str(path), img)
+    back = load_image(str(path))
+    # Single-channel images round-trip as (H, W) per load_image's contract.
+    assert back.shape == (8, 8)
+    np.testing.assert_allclose(np.array(back), np.array(img), atol=1.0 / 255 + 1e-4)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,53 @@
+"""Smoke tests: the package imports and its public API is wired together."""
+
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+import mlx3d
+
+SUBPACKAGES = [
+    "cameras",
+    "datasets",
+    "io",
+    "losses",
+    "nn",
+    "ops",
+    "renderer",
+    "splatting",
+    "structures",
+    "transforms",
+    "utils",
+]
+
+
+def test_version_present():
+    assert isinstance(mlx3d.__version__, str)
+    assert mlx3d.__version__.count(".") >= 1
+
+
+def test_top_level_exports_importable():
+    for name in mlx3d.__all__:
+        assert hasattr(mlx3d, name), f"mlx3d.{name} missing"
+
+
+@pytest.mark.parametrize("pkg_name", SUBPACKAGES)
+def test_subpackage_all_symbols_resolve(pkg_name):
+    pkg = importlib.import_module(f"mlx3d.{pkg_name}")
+    assert hasattr(pkg, "__all__"), f"mlx3d.{pkg_name} has no __all__"
+    for name in pkg.__all__:
+        assert hasattr(pkg, name), f"mlx3d.{pkg_name}.{name} declared but missing"
+
+
+_EXAMPLES = sorted(p for p in (Path(__file__).resolve().parents[1] / "examples").glob("*.py"))
+
+
+@pytest.mark.parametrize("example_path", _EXAMPLES, ids=lambda p: p.name)
+def test_examples_import_clean(example_path):
+    """Each example module imports without error (``main()`` is not invoked)."""
+    spec = importlib.util.spec_from_file_location(example_path.stem, example_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert hasattr(module, "main"), f"{example_path.name} should expose main()"


### PR DESCRIPTION
Release polish for v0.1. Additive where possible — the existing API was already clean.

## Library
- **`io.save_image` / `load_image`** — one call to write any renderer output to disk and read it back; removes PIL boilerplate from the examples.
- **`Renderer` protocol + `RenderOutput`** in `mlx3d.renderer` — formalizes the `(camera, scene) -> {image, alpha, depth}` contract every image renderer already follows. A `typing.Protocol`, no base classes to subclass.
- **Bug fix in `render_mesh_soft`** — multi-face meshes produced `NaN`: off-triangle barycentric coords pushed `z_face` below `znear` and overflowed the depth weighting (`coverage=0 * exp=inf`). Clamp the exponent at 0. Covered by a regression test.

## Examples (all self-contained, no downloads, run in seconds)
`render_mesh`, `raytrace_volume`, `extract_mesh`, `fit_nerf`, `fit_gaussians`, `extend_renderer`, plus the existing mesh/pointcloud fits. The COLMAP/Blender training scripts are unchanged. See `examples/README.md`.

## Tests (100 → 134)
Organized into `smoke / unit / behavior / data` markers, sliced centrally in `conftest.py`:
- `test_smoke` — public API + every example imports
- `test_behavior` — gradient/optimization end to end, including the multi-face no-NaN regression (seeded for determinism)
- `test_image_io` — image round-trips

## CI & docs
- `tests.yml`: fast ubuntu lint job (ruff check + format) gating the macOS test matrix, which now runs smoke / unit+data / behavior separately.
- New "Extending MLX3D" tutorial and a README examples section; whole repo ruff-formatted.

**Verification:** `ruff check` clean, `ruff format --check` clean, 134 tests pass (~4s), `mkdocs build --strict` exits 0.