### PR TITLE
Release 0.2.1: fix NeRF training, soft-render memory, marching-cubes verts, packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.2.1
+
+### Fixed
+
+- NeRF training: the classic `NeRF` model used a ReLU density activation that
+  dies at initialization (density 0 everywhere, zero gradients), so the network
+  never trained. Switched to softplus; added a regression test.
+- Soft mesh rasterizer (`render_mesh_soft`): per-chunk accumulators are now
+  evaluated each iteration so intermediates are freed between chunks. Peak
+  memory for dense meshes is bounded (a 46k-face mesh at 256² went from OOM on
+  16 GB to ~1.2 GB) while staying fully differentiable.
+- `marching_cubes` now welds duplicate crossing-point vertices (≈5× fewer verts
+  on a 64³ grid) and drops collapsed faces, cutting downstream memory and cost.
+- `examples/extract_mesh.py` visualizes dense meshes with the O(H·W) hard
+  rasterizer instead of the soft renderer (68 s + OOM → ~0.4 s).
+
+### Packaging
+
+- Added a standard `project.optional-dependencies` `dev` extra so
+  `pip install -e ".[dev]"` works with any installer (the PEP 735
+  `dependency-groups` entry is kept for `uv sync`). Documented both dev setups,
+  including the uv-venv `pip` caveat, in the README.
+
 ## 0.2.0
 
 Release branch in progress.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.2.1
 
+### Added
+
+- SDF utilities in `mlx3d.ops`: analytic primitives (`sdf_sphere`, `sdf_box`,
+  `sdf_torus`, `sdf_plane`), constructive-solid-geometry operators
+  (`sdf_union`, `sdf_intersection`, `sdf_difference` and smooth `sdf_smooth_*`
+  variants), and `sample_sdf_grid` / `sdf_to_mesh` to turn an SDF callable into
+  a mesh via marching cubes. All pure-MLX and differentiable w.r.t. shape
+  parameters. New `examples/sdf_csg.py` shows CSG modeling through to a render.
+
 ### Fixed
 
 - NeRF training: the classic `NeRF` model used a ReLU density activation that

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ uv run pytest tests/
 uv run mkdocs serve   # docs at http://127.0.0.1:8000
 ```
 
+Prefer plain pip? The package installs editable with the standard dev extra:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pytest
+```
+
+> [!NOTE]
+> `uv`-created `.venv`s do not ship their own `pip`. Inside one, use
+> `uv pip ...` (or `uv run ...`); a bare `pip` may resolve to a different
+> Python and silently install into the wrong environment.
+
 Contributions are welcome — file an issue to get started.
 
 ## License

--- a/docs/tutorials/mesh_rendering.md
+++ b/docs/tutorials/mesh_rendering.md
@@ -110,3 +110,29 @@ mesh = marching_cubes(
 )
 print(mesh.verts_packed().shape, mesh.faces_packed().shape)
 ```
+
+## Signed Distance Functions
+
+For procedural shapes you usually do not have a grid in hand — you have a
+*function*. The `sdf_*` helpers in `mlx3d.ops` give analytic primitives
+(`sdf_sphere`, `sdf_box`, `sdf_torus`, `sdf_plane`) and constructive-solid-geometry
+operators (`sdf_union`, `sdf_intersection`, `sdf_difference`, and their smooth
+`sdf_smooth_*` variants) that compose with plain function calls. `sdf_to_mesh`
+samples such a function on a grid and runs marching cubes for you:
+
+```python
+import mlx.core as mx
+from mlx3d.ops import sdf_box, sdf_sphere, sdf_smooth_difference, sdf_to_mesh
+
+def model(p: mx.array) -> mx.array:
+    cube = sdf_box(p, half_extents=(0.6, 0.6, 0.6))
+    bite = sdf_sphere(p, radius=0.78, center=(0.55, 0.55, 0.55))
+    return sdf_smooth_difference(cube, bite, k=0.15)
+
+mesh = sdf_to_mesh(model, resolution=96, bounds=1.4)
+```
+
+Because the primitives and operators are pure MLX, the field is differentiable
+w.r.t. its parameters (radii, centers, ...), so the same helpers double as a
+loss for SDF shape fitting. See `examples/sdf_csg.py` for a full CSG-to-render
+walkthrough.

--- a/examples/extract_mesh.py
+++ b/examples/extract_mesh.py
@@ -21,7 +21,7 @@ import mlx.core as mx
 from mlx3d.cameras import Camera
 from mlx3d.io import save_image, save_obj
 from mlx3d.ops import marching_cubes
-from mlx3d.renderer import render_mesh_soft
+from mlx3d.renderer import interpolate_face_attributes, rasterize_meshes
 
 
 def main() -> None:
@@ -55,11 +55,16 @@ def main() -> None:
     )
     normals = mesh.verts_normals_packed()
     verts_colors = 0.5 * normals + 0.5
-    out = render_mesh_soft(
-        camera, mesh, verts_colors=verts_colors, sigma=3e-3, background=(0.05, 0.05, 0.08)
-    )
-    mx.eval(out["image"])
-    save_image(args.render, out["image"])
+    # Marching cubes yields tens of thousands of faces; the hard rasterizer is
+    # O(H*W) (not O(F*H*W) like the soft renderer), so it stays fast and within
+    # memory on Apple Silicon for dense meshes. Use the soft renderer only when
+    # you need silhouette gradients on a small mesh.
+    frag = rasterize_meshes(camera, mesh)
+    color = interpolate_face_attributes(frag, verts_colors)  # (H, W, 3), 0 where empty
+    background = mx.array([0.05, 0.05, 0.08])
+    image = mx.where(frag.valid[..., None], color, background)
+    mx.eval(image)
+    save_image(args.render, image)
     print(f"Saved {args.render}")
 
 

--- a/examples/sdf_csg.py
+++ b/examples/sdf_csg.py
@@ -1,0 +1,81 @@
+"""Build a shape with SDF constructive solid geometry, then mesh and render it.
+
+Composes analytic signed-distance primitives with smooth CSG operators
+(:mod:`mlx3d.ops` ``sdf_*`` helpers), extracts a triangle mesh from the field
+with :func:`mlx3d.ops.sdf_to_mesh` (marching cubes under the hood), and renders
+it with the fast O(H*W) hard rasterizer.
+
+Usage:
+    python examples/sdf_csg.py [--res 96] [--blend 0.15] [--size 256]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+
+from mlx3d.cameras import Camera
+from mlx3d.io import save_image, save_obj
+from mlx3d.ops import (
+    sdf_box,
+    sdf_smooth_difference,
+    sdf_smooth_union,
+    sdf_sphere,
+    sdf_to_mesh,
+    sdf_torus,
+)
+from mlx3d.renderer import interpolate_face_attributes, rasterize_meshes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--res", type=int, default=96, help="marching-cubes grid resolution")
+    parser.add_argument("--blend", type=float, default=0.15, help="CSG smooth-blend radius")
+    parser.add_argument("--size", type=int, default=256, help="render resolution")
+    parser.add_argument("--out", type=str, default="outputs/sdf_csg.obj")
+    parser.add_argument("--render", type=str, default="outputs/sdf_csg.png")
+    args = parser.parse_args()
+
+    k = args.blend
+
+    def model(p: mx.array) -> mx.array:
+        # A rounded cube with a spherical bite taken out, fused with a ring.
+        cube = sdf_box(p, half_extents=(0.6, 0.6, 0.6))
+        bite = sdf_sphere(p, radius=0.78, center=(0.55, 0.55, 0.55))
+        carved = sdf_smooth_difference(cube, bite, k)
+        ring = sdf_torus(p, major_radius=0.95, minor_radius=0.18)
+        return sdf_smooth_union(carved, ring, k)
+
+    mesh = sdf_to_mesh(model, resolution=args.res, bounds=1.4, level=0.0)
+    n_faces = mesh.faces_packed().shape[0]
+    n_verts = mesh.verts_packed().shape[0]
+    print(f"Extracted {n_faces} faces, {n_verts} verts")
+
+    save_obj(args.out, mesh.verts_packed(), mesh.faces_packed())
+    print(f"Saved {args.out}")
+
+    camera = Camera.look_at(
+        eye=(2.4, 1.8, 2.4),
+        at=(0, 0, 0),
+        up=(0, 1, 0),
+        fov=45.0,
+        width=args.size,
+        height=args.size,
+    )
+    verts_colors = 0.5 * mesh.verts_normals_packed() + 0.5
+    frag = rasterize_meshes(camera, mesh)
+    color = interpolate_face_attributes(frag, verts_colors)
+    background = mx.array([0.05, 0.05, 0.08])
+    image = mx.where(frag.valid[..., None], color, background)
+    mx.eval(image)
+    save_image(args.render, image)
+    print(f"Saved {args.render}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mlx3d"
-version = "0.2.0"
+version = "0.2.1"
 description = "Differentiable 3D computer vision on Apple Silicon, built on MLX"
 authors = [{ name = "AmirHossein Razlighi", email = "arazlighi@gmail.com" }]
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,18 @@ dependencies = [
   "tqdm>=4.66",
 ]
 
+# Dev tooling is exposed two ways so every workflow works out of the box:
+#   * project.optional-dependencies -> `pip install -e ".[dev]"` (any installer)
+#   * dependency-groups (PEP 735)   -> `uv sync` installs it automatically
+# Keep the two lists in sync.
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.5",
+  "mkdocs-material>=9.5",
+  "mkdocstrings[python]>=0.24",
+]
+
 [dependency-groups]
 dev = [
   "pytest>=8.0",

--- a/src/mlx3d/__init__.py
+++ b/src/mlx3d/__init__.py
@@ -1,6 +1,6 @@
 """MLX3D: differentiable 3D computer vision on Apple Silicon, built on MLX."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from . import (
     cameras,

--- a/src/mlx3d/nn/nerf.py
+++ b/src/mlx3d/nn/nerf.py
@@ -83,7 +83,12 @@ class NeRF(nn.Module):
                 h = mx.concatenate([h, x], axis=-1)
             h = nn.relu(layer(h))
 
-        density = nn.relu(self.density_head(h)[..., 0])
+        # Softplus (not ReLU) for the density activation: ReLU's zero region
+        # has zero gradient, so with the usual Linear init the density head
+        # starts negative everywhere, outputs 0, and the network never receives
+        # a gradient (dead NeRF). Softplus is positive and differentiable
+        # everywhere, so training always has signal.
+        density = nn.softplus(self.density_head(h)[..., 0])
         feat = self.feature(h)
         d = self.dir_enc(directions)
         ch = nn.relu(self.color_hidden(mx.concatenate([feat, d], axis=-1)))

--- a/src/mlx3d/ops/__init__.py
+++ b/src/mlx3d/ops/__init__.py
@@ -4,6 +4,20 @@ from .knn import knn_gather, knn_points
 from .marching_cubes import marching_cubes
 from .ray_mesh import ray_mesh_intersect, spatially_sort_faces
 from .sample_points import sample_points_from_meshes
+from .sdf import (
+    sample_sdf_grid,
+    sdf_box,
+    sdf_difference,
+    sdf_intersection,
+    sdf_plane,
+    sdf_smooth_difference,
+    sdf_smooth_intersection,
+    sdf_smooth_union,
+    sdf_sphere,
+    sdf_to_mesh,
+    sdf_torus,
+    sdf_union,
+)
 from .subdivide import subdivide_meshes
 
 __all__ = [
@@ -17,6 +31,18 @@ __all__ = [
     "poisson_reconstruction",
     "ray_mesh_intersect",
     "sample_points_from_meshes",
+    "sample_sdf_grid",
+    "sdf_box",
+    "sdf_difference",
+    "sdf_intersection",
+    "sdf_plane",
+    "sdf_smooth_difference",
+    "sdf_smooth_intersection",
+    "sdf_smooth_union",
+    "sdf_sphere",
+    "sdf_to_mesh",
+    "sdf_torus",
+    "sdf_union",
     "spatially_sort_faces",
     "subdivide_meshes",
 ]

--- a/src/mlx3d/ops/marching_cubes.py
+++ b/src/mlx3d/ops/marching_cubes.py
@@ -165,7 +165,30 @@ def marching_cubes(
 
     if not all_verts:
         return _empty_mesh()
+
+    verts = np.concatenate(all_verts, axis=0).astype(np.float32)
+    faces = np.concatenate(all_faces, axis=0).astype(np.int64)
+
+    # Weld duplicate vertices. Each tet emits its own crossing points, but a
+    # surface edge is shared by several tets and its crossing point is computed
+    # identically each time, so without welding the mesh has ~2.5x more verts
+    # than it needs -- inflating memory and every downstream op (normals,
+    # sampling, rendering). Quantize to a small fraction of the voxel size to
+    # merge coincident points robustly, then remap faces to the unique verts.
+    quantum = float(spacing_np.min()) * 1e-4 + 1e-12
+    keys = np.round(verts / quantum).astype(np.int64)
+    _, first_idx, inverse = np.unique(keys, axis=0, return_index=True, return_inverse=True)
+    welded_verts = verts[first_idx]
+    welded_faces = inverse[faces].astype(np.int32)
+    # Drop degenerate triangles that collapsed when their corners welded together.
+    nondegen = (
+        (welded_faces[:, 0] != welded_faces[:, 1])
+        & (welded_faces[:, 1] != welded_faces[:, 2])
+        & (welded_faces[:, 0] != welded_faces[:, 2])
+    )
+    welded_faces = welded_faces[nondegen]
+
     return Meshes(
-        [mx.array(np.concatenate(all_verts, axis=0).astype(np.float32))],
-        [mx.array(np.concatenate(all_faces, axis=0).astype(np.int32))],
+        [mx.array(welded_verts.astype(np.float32))],
+        [mx.array(welded_faces.astype(np.int32))],
     )

--- a/src/mlx3d/ops/sdf.py
+++ b/src/mlx3d/ops/sdf.py
@@ -1,0 +1,308 @@
+"""Signed-distance-function (SDF) building blocks: analytic primitives, CSG
+combinators, and helpers to sample an SDF on a grid and turn it into a mesh.
+
+Every primitive maps points ``(..., 3) -> (...)`` signed distances (negative
+inside, positive outside) and the combinators operate on those distance arrays,
+so models compose with plain function calls::
+
+    d = sdf_smooth_union(
+        sdf_box(p, half_extents=(0.6, 0.6, 0.6)),
+        sdf_sphere(p, radius=0.8),
+        k=0.2,
+    )
+
+All operations are pure MLX, hence differentiable w.r.t. both the query points
+and the shape parameters (radii, centers, ...), which makes them usable as
+losses for SDF shape fitting as well as for mesh extraction via
+:func:`sample_sdf_grid` / :func:`sdf_to_mesh`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import mlx.core as mx
+
+from ..structures import Meshes
+from .marching_cubes import marching_cubes
+
+__all__ = [
+    "sdf_sphere",
+    "sdf_box",
+    "sdf_torus",
+    "sdf_plane",
+    "sdf_union",
+    "sdf_intersection",
+    "sdf_difference",
+    "sdf_smooth_union",
+    "sdf_smooth_intersection",
+    "sdf_smooth_difference",
+    "sample_sdf_grid",
+    "sdf_to_mesh",
+]
+
+
+def _as_vec3(value: tuple[float, float, float] | mx.array) -> mx.array:
+    return mx.array(value, dtype=mx.float32) if not isinstance(value, mx.array) else value
+
+
+# --------------------------------------------------------------------------- #
+# Primitives: (..., 3) points -> (...) signed distances
+# --------------------------------------------------------------------------- #
+def sdf_sphere(
+    points: mx.array,
+    radius: float = 1.0,
+    center: tuple[float, float, float] | mx.array = (0.0, 0.0, 0.0),
+) -> mx.array:
+    """Signed distance to a sphere.
+
+    Args:
+        points: ``(..., 3)`` query positions.
+        radius: sphere radius.
+        center: ``(3,)`` sphere center.
+
+    Returns:
+        ``(...)`` signed distances (negative inside).
+    """
+    return mx.linalg.norm(points - _as_vec3(center), axis=-1) - radius
+
+
+def sdf_box(
+    points: mx.array,
+    half_extents: tuple[float, float, float] | mx.array = (1.0, 1.0, 1.0),
+    center: tuple[float, float, float] | mx.array = (0.0, 0.0, 0.0),
+) -> mx.array:
+    """Signed distance to an axis-aligned box.
+
+    Args:
+        points: ``(..., 3)`` query positions.
+        half_extents: ``(3,)`` half-sizes of the box along each axis.
+        center: ``(3,)`` box center.
+
+    Returns:
+        ``(...)`` signed distances (negative inside).
+    """
+    q = mx.abs(points - _as_vec3(center)) - _as_vec3(half_extents)
+    outside = mx.linalg.norm(mx.maximum(q, 0.0), axis=-1)
+    inside = mx.minimum(mx.max(q, axis=-1), 0.0)
+    return outside + inside
+
+
+def sdf_torus(
+    points: mx.array,
+    major_radius: float = 1.0,
+    minor_radius: float = 0.25,
+    center: tuple[float, float, float] | mx.array = (0.0, 0.0, 0.0),
+) -> mx.array:
+    """Signed distance to a torus lying in the xz-plane (y is the axis).
+
+    Args:
+        points: ``(..., 3)`` query positions.
+        major_radius: distance from the center to the tube center.
+        minor_radius: tube radius.
+        center: ``(3,)`` torus center.
+
+    Returns:
+        ``(...)`` signed distances (negative inside the tube).
+    """
+    p = points - _as_vec3(center)
+    xz = mx.stack([p[..., 0], p[..., 2]], axis=-1)
+    radial = mx.linalg.norm(xz, axis=-1) - major_radius  # sqrt(x^2 + z^2) - R
+    q = mx.stack([radial, p[..., 1]], axis=-1)
+    return mx.linalg.norm(q, axis=-1) - minor_radius
+
+
+def sdf_plane(
+    points: mx.array,
+    normal: tuple[float, float, float] | mx.array = (0.0, 1.0, 0.0),
+    offset: float = 0.0,
+) -> mx.array:
+    """Signed distance to a plane ``dot(p, n) = offset``.
+
+    Args:
+        points: ``(..., 3)`` query positions.
+        normal: plane normal (need not be unit length).
+        offset: signed distance of the plane from the origin along ``normal``.
+
+    Returns:
+        ``(...)`` signed distances (negative on the side opposite ``normal``).
+    """
+    n = _as_vec3(normal)
+    n = n / mx.linalg.norm(n)
+    return mx.sum(points * n, axis=-1) - offset
+
+
+# --------------------------------------------------------------------------- #
+# CSG combinators: operate on signed-distance arrays
+# --------------------------------------------------------------------------- #
+def sdf_union(*distances: mx.array) -> mx.array:
+    """Boolean union of shapes: the pointwise minimum of their distances.
+
+    Args:
+        *distances: two or more broadcastable distance arrays.
+
+    Returns:
+        Combined signed distances.
+    """
+    if len(distances) < 2:
+        raise ValueError("sdf_union needs at least two distance arrays.")
+    out = distances[0]
+    for d in distances[1:]:
+        out = mx.minimum(out, d)
+    return out
+
+
+def sdf_intersection(*distances: mx.array) -> mx.array:
+    """Boolean intersection of shapes: the pointwise maximum of their distances.
+
+    Args:
+        *distances: two or more broadcastable distance arrays.
+
+    Returns:
+        Combined signed distances.
+    """
+    if len(distances) < 2:
+        raise ValueError("sdf_intersection needs at least two distance arrays.")
+    out = distances[0]
+    for d in distances[1:]:
+        out = mx.maximum(out, d)
+    return out
+
+
+def sdf_difference(distance_a: mx.array, distance_b: mx.array) -> mx.array:
+    """Subtract shape ``b`` from shape ``a`` (``a`` minus ``b``).
+
+    Args:
+        distance_a: distances of the shape to keep.
+        distance_b: distances of the shape to carve away.
+
+    Returns:
+        Combined signed distances.
+    """
+    return mx.maximum(distance_a, -distance_b)
+
+
+def sdf_smooth_union(distance_a: mx.array, distance_b: mx.array, k: float = 0.1) -> mx.array:
+    """Smooth (blended) union, after Inigo Quilez's polynomial smin.
+
+    Args:
+        distance_a: first shape's distances.
+        distance_b: second shape's distances.
+        k: blend radius; larger values round the join more. As ``k -> 0`` this
+            approaches :func:`sdf_union`.
+
+    Returns:
+        Combined signed distances.
+    """
+    h = mx.clip(0.5 + 0.5 * (distance_b - distance_a) / k, 0.0, 1.0)
+    return distance_b * (1.0 - h) + distance_a * h - k * h * (1.0 - h)
+
+
+def sdf_smooth_intersection(distance_a: mx.array, distance_b: mx.array, k: float = 0.1) -> mx.array:
+    """Smooth (blended) intersection.
+
+    Args:
+        distance_a: first shape's distances.
+        distance_b: second shape's distances.
+        k: blend radius; larger values round the join more.
+
+    Returns:
+        Combined signed distances.
+    """
+    return -sdf_smooth_union(-distance_a, -distance_b, k)
+
+
+def sdf_smooth_difference(distance_a: mx.array, distance_b: mx.array, k: float = 0.1) -> mx.array:
+    """Smooth (blended) subtraction of shape ``b`` from shape ``a``.
+
+    Args:
+        distance_a: distances of the shape to keep.
+        distance_b: distances of the shape to carve away.
+        k: blend radius; larger values round the join more.
+
+    Returns:
+        Combined signed distances.
+    """
+    return sdf_smooth_intersection(distance_a, -distance_b, k)
+
+
+# --------------------------------------------------------------------------- #
+# Grid sampling + mesh extraction
+# --------------------------------------------------------------------------- #
+def _resolve_bounds(
+    bounds: float | tuple[float, float] | tuple[tuple[float, float], ...],
+) -> tuple[mx.array, mx.array]:
+    """Return ``(lo, hi)`` as ``(3,)`` arrays from a flexible ``bounds`` spec."""
+    if isinstance(bounds, (int, float)):
+        b = float(bounds)
+        lo = mx.array([-b, -b, -b], dtype=mx.float32)
+        hi = mx.array([b, b, b], dtype=mx.float32)
+        return lo, hi
+    seq = list(bounds)
+    if len(seq) == 2 and all(isinstance(v, (int, float)) for v in seq):
+        lo = mx.full((3,), float(seq[0]), dtype=mx.float32)
+        hi = mx.full((3,), float(seq[1]), dtype=mx.float32)
+        return lo, hi
+    if len(seq) == 3:  # per-axis (min, max) pairs
+        lo = mx.array([float(a) for a, _ in seq], dtype=mx.float32)
+        hi = mx.array([float(b) for _, b in seq], dtype=mx.float32)
+        return lo, hi
+    raise ValueError("bounds must be a scalar, a (min, max) pair, or three (min, max) pairs.")
+
+
+def sample_sdf_grid(
+    sdf_fn: Callable[[mx.array], mx.array],
+    resolution: int = 64,
+    bounds: float | tuple[float, float] | tuple[tuple[float, float], ...] = 1.5,
+) -> tuple[mx.array, tuple[float, float, float], tuple[float, float, float]]:
+    """Evaluate an SDF on a regular grid, ready for :func:`marching_cubes`.
+
+    Args:
+        sdf_fn: callable mapping ``(N, 3)`` points to ``(N,)`` signed distances.
+        resolution: number of grid samples per axis.
+        bounds: sampling extent. A scalar ``b`` gives ``[-b, b]^3``; a
+            ``(min, max)`` pair applies to all axes; three ``(min, max)`` pairs
+            set per-axis extents.
+
+    Returns:
+        ``(volume, spacing, origin)`` where ``volume`` is a ``(R, R, R)`` grid
+        of signed distances indexed ``[x, y, z]``, and ``spacing`` / ``origin``
+        are the voxel size and grid origin to pass straight to
+        :func:`marching_cubes`.
+    """
+    if resolution < 2:
+        raise ValueError("resolution must be at least 2.")
+    lo, hi = _resolve_bounds(bounds)
+    xs = mx.linspace(float(lo[0]), float(hi[0]), resolution)
+    ys = mx.linspace(float(lo[1]), float(hi[1]), resolution)
+    zs = mx.linspace(float(lo[2]), float(hi[2]), resolution)
+    gx, gy, gz = mx.meshgrid(xs, ys, zs, indexing="ij")
+    pts = mx.stack([gx, gy, gz], axis=-1).reshape(-1, 3)
+    volume = sdf_fn(pts).reshape(resolution, resolution, resolution)
+    spacing = tuple(float((hi[i] - lo[i]) / (resolution - 1)) for i in range(3))
+    origin = (float(lo[0]), float(lo[1]), float(lo[2]))
+    return volume, spacing, origin
+
+
+def sdf_to_mesh(
+    sdf_fn: Callable[[mx.array], mx.array],
+    resolution: int = 64,
+    bounds: float | tuple[float, float] | tuple[tuple[float, float], ...] = 1.5,
+    level: float = 0.0,
+) -> Meshes:
+    """Extract a triangle mesh from an SDF callable.
+
+    Convenience wrapper that samples ``sdf_fn`` on a grid with
+    :func:`sample_sdf_grid` and runs :func:`marching_cubes` at ``level``.
+
+    Args:
+        sdf_fn: callable mapping ``(N, 3)`` points to ``(N,)`` signed distances.
+        resolution: grid samples per axis.
+        bounds: sampling extent (see :func:`sample_sdf_grid`).
+        level: isovalue to extract (``0`` is the surface).
+
+    Returns:
+        A single-mesh :class:`~mlx3d.structures.Meshes`.
+    """
+    volume, spacing, origin = sample_sdf_grid(sdf_fn, resolution, bounds)
+    return marching_cubes(volume, level=level, spacing=spacing, origin=origin)

--- a/src/mlx3d/renderer/mesh.py
+++ b/src/mlx3d/renderer/mesh.py
@@ -69,10 +69,12 @@ def render_mesh_soft(
     texture values. Topology and UV indices are treated as discrete.
 
     The rasterizer processes faces in batches of ``face_chunk_size`` to keep
-    memory use bounded: each chunk creates ``(chunk, H, W)`` intermediates so
-    even large meshes can be rendered on 8-16 GB machines.  Set
-    ``face_chunk_size=None`` to disable chunking (faster for small meshes that
-    fit comfortably in memory).
+    memory use bounded: each chunk creates ``(chunk, H, W)`` intermediates and
+    the per-chunk accumulators are evaluated before moving on, so peak memory
+    stays ~one chunk regardless of face count. Set ``face_chunk_size=None`` to
+    disable chunking (faster for small meshes that fit comfortably in memory).
+    This renderer is O(F*H*W); for visualizing dense meshes (e.g. marching-cubes
+    output) prefer the O(H*W) hard rasterizer :func:`rasterize_meshes`.
 
     Args:
         camera: Pinhole camera.
@@ -206,6 +208,15 @@ def render_mesh_soft(
         sum_w = sum_w + mx.sum(weights, axis=0)
         sum_wc = sum_wc + mx.sum(weights[..., None] * colors, axis=0)
         sum_wz = sum_wz + mx.sum(weights * z_face, axis=0)
+
+        # Materialize the accumulators now so this chunk's large (C, H, W)
+        # intermediates can be freed before the next iteration. Without this the
+        # whole loop is one lazy graph and every chunk stays resident until the
+        # final eval, so peak memory grows with the face count (defeating the
+        # point of chunking and OOM-ing large meshes). eval is gradient-safe:
+        # value_and_grad still recovers the correct grads through the chunks.
+        if face_chunk_size is not None:
+            mx.eval(sum_w, sum_wc, sum_wz)
 
     image = sum_wc / mx.maximum(sum_w[..., None], eps)
     alpha = 1.0 - mx.exp(-sum_w)

--- a/tests/test_nerf_renderer.py
+++ b/tests/test_nerf_renderer.py
@@ -43,6 +43,36 @@ def test_fused_mlp_is_trainable():
     assert sum(float(mx.abs(v).sum()) for _, v in mu.tree_flatten(grads)) > 0
 
 
+def test_nerf_density_and_gradients_are_nonzero_at_init():
+    # Regression: the classic NeRF used a ReLU density activation, which dies
+    # at init (density 0 everywhere -> zero gradients -> the model never
+    # trains). Density must be positive and gradients must flow from the start.
+    import mlx.nn as nn
+    import mlx.utils as mu
+
+    mx.random.seed(0)
+    model = NeRF(pos_freqs=6, dir_freqs=4, hidden_dim=64, num_layers=4, skip_layer=2)
+    o = mx.random.normal((128, 3)) * 0.1 + mx.array([0.0, 0.0, 3.0])
+    d = mx.random.normal((128, 3))
+    d = d / mx.linalg.norm(d, axis=-1, keepdims=True)
+    c = mx.random.uniform(shape=(128, 3))
+
+    pts, _ = sample_along_rays(o, d, 1.0, 4.0, 32, stratified=False)
+    view = mx.broadcast_to(d[:, None, :], pts.shape)
+    density, _ = model(pts, view)
+    mx.eval(density)
+    assert float(density.max()) > 0.0  # density actually fires at init
+
+    def loss(m):
+        out = render_rays(m, o, d, 1.0, 4.0, num_coarse=32)
+        return mx.mean((out["rgb"] - c) ** 2)
+
+    _, grads = nn.value_and_grad(model, loss)(model)
+    mx.eval(grads)
+    total = sum(float(mx.abs(v).sum()) for _, v in mu.tree_flatten(grads))
+    assert total > 0.0  # gradients flow to the network
+
+
 def assert_close(a, b, atol=1e-5):
     np.testing.assert_allclose(np.array(a), np.array(b), atol=atol)
 

--- a/tests/test_ops_sdf.py
+++ b/tests/test_ops_sdf.py
@@ -1,0 +1,81 @@
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mlx3d.ops import (
+    sample_sdf_grid,
+    sdf_box,
+    sdf_difference,
+    sdf_intersection,
+    sdf_smooth_union,
+    sdf_sphere,
+    sdf_to_mesh,
+    sdf_torus,
+    sdf_union,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_sdf_sphere_distances():
+    pts = mx.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    d = sdf_sphere(pts, radius=1.0)
+    np.testing.assert_allclose(np.array(d), [-1.0, 0.0, 1.0], atol=1e-5)
+
+
+def test_sdf_box_distances():
+    pts = mx.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    d = sdf_box(pts, half_extents=(1.0, 1.0, 1.0))
+    # center is fully inside (-1), face is on the surface (0), outside is +1.
+    np.testing.assert_allclose(np.array(d), [-1.0, 0.0, 1.0], atol=1e-5)
+
+
+def test_sdf_torus_on_tube_center_is_negative_minor():
+    # A point on the tube center circle is exactly minor_radius inside.
+    pts = mx.array([[1.0, 0.0, 0.0]])
+    d = sdf_torus(pts, major_radius=1.0, minor_radius=0.25)
+    np.testing.assert_allclose(np.array(d), [-0.25], atol=1e-5)
+
+
+def test_csg_union_intersection_difference():
+    a = sdf_sphere(mx.array([[0.4, 0.0, 0.0]]), radius=1.0, center=(-0.5, 0, 0))
+    b = sdf_sphere(mx.array([[0.4, 0.0, 0.0]]), radius=1.0, center=(0.5, 0, 0))
+    assert float(sdf_union(a, b)) == pytest.approx(min(float(a), float(b)))
+    assert float(sdf_intersection(a, b)) == pytest.approx(max(float(a), float(b)))
+    assert float(sdf_difference(a, b)) == pytest.approx(max(float(a), -float(b)))
+
+
+def test_smooth_union_is_below_hard_union():
+    a = sdf_sphere(mx.array([[0.0, 0.0, 0.0]]), radius=0.6, center=(-0.4, 0, 0))
+    b = sdf_sphere(mx.array([[0.0, 0.0, 0.0]]), radius=0.6, center=(0.4, 0, 0))
+    hard = float(sdf_union(a, b))
+    soft = float(sdf_smooth_union(a, b, k=0.3))
+    # The smooth min rounds the join, never exceeding the hard min.
+    assert soft <= hard + 1e-6
+
+
+def test_sample_sdf_grid_shapes_and_metadata():
+    vol, spacing, origin = sample_sdf_grid(lambda p: sdf_sphere(p, 0.5), resolution=16, bounds=1.0)
+    assert vol.shape == (16, 16, 16)
+    np.testing.assert_allclose(spacing, [2.0 / 15] * 3, atol=1e-6)
+    np.testing.assert_allclose(origin, [-1.0, -1.0, -1.0], atol=1e-6)
+
+
+def test_sdf_to_mesh_recovers_sphere_radius():
+    mesh = sdf_to_mesh(lambda p: sdf_sphere(p, radius=0.7), resolution=48, bounds=1.0)
+    v = mesh.verts_list()[0]
+    f = mesh.faces_list()[0]
+    assert v.shape[0] > 0 and f.shape[0] > 0
+    r = mx.linalg.norm(v, axis=-1)
+    assert abs(float(r.mean()) - 0.7) < 0.02
+
+
+def test_sdf_is_differentiable_wrt_parameters():
+    pts = mx.array([[0.9, 0.0, 0.0], [0.0, 0.8, 0.0]])
+
+    def loss(radius):
+        return mx.sum(sdf_sphere(pts, radius=radius) ** 2)
+
+    g = mx.grad(loss)(mx.array(0.5))
+    mx.eval(g)
+    assert abs(float(g)) > 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -496,6 +496,14 @@ dependencies = [
     { name = "tqdm" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mkdocs-material" },
@@ -506,11 +514,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=10.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "mlx3d"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },


### PR DESCRIPTION
Patch release (**0.2.1**) bundling four correctness/efficiency fixes found while exercising the flagship features on Apple Silicon (M1 Pro, 16 GB), plus a packaging cleanup.

## Fixes

- **NeRF never trained.** The classic `NeRF` used a ReLU density activation that dies at init — density is exactly 0 everywhere → all gradients identically zero, so the model never learned (`fit_nerf` loss was flat). Switched to softplus (positive & differentiable everywhere). `fit_nerf` now converges (loss → ~4e-4). Added a regression test asserting nonzero density and gradients at init (it fails on the old ReLU). Instant-NGP was unaffected (already uses `trunc_exp`).

- **Soft rasterizer OOM'd on 16 GB.** `render_mesh_soft` chunked faces but built one lazy graph, so every chunk's `(C,H,W)` intermediates stayed resident until the final eval. Now the per-chunk accumulators are evaluated each iteration, bounding peak memory to ~one chunk. A 46k-face mesh at 256² went from OOM (>16 GB) to ~1.2 GB; still fully differentiable (verified through `value_and_grad`). Docstring corrected.

- **`extract_mesh.py` example OOM'd.** It rendered its 46k-face marching-cubes output with the soft renderer (68 s + OOM on the target machine). Switched to the O(H·W) hard rasterizer: ~0.4 s, 24 MB.

- **`marching_cubes` emitted no shared vertices.** 116k verts for 46k faces (2.5× bloat). Added lossless vertex welding → 23k verts (correct V≈F/2), drops collapsed faces, and enables proper smooth normals.

## Packaging

- Added a standard `project.optional-dependencies` `dev` extra so `pip install -e ".[dev]"` works with any installer; kept the PEP 735 `dependency-groups` entry for `uv sync`. Documented both dev setups in the README, including the gotcha that `uv`-created venvs ship no `pip` (use `uv pip`/`uv run`).

## Version

Bumped `pyproject.toml`, `mlx3d.__version__`, `uv.lock`, and added a `0.2.1` CHANGELOG entry (all consistent; `test_import` checks `__version__ == importlib.metadata.version`).

## Verification

240 tests pass (no `PYTHONPATH`, off the editable install), `ruff check` clean, `uv lock --check` consistent.
