### PR TITLE
Add py.typed and a rasterizer gradient-correctness harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Type support: mlx3d now ships a `py.typed` marker, so downstream projects
+  get its inline type hints under mypy / pyright.
+- Finite-difference gradient check for the Metal Gaussian rasterizer's
+  hand-written backward pass (`examples/validate_gaussian_gradients.py` plus a
+  `unit` test). Confirms the analytic gradients match numerical derivatives
+  (geometry to ~1e-2, appearance to ~1e-3), a runnable correctness artifact on
+  Apple Silicon.
+
 - Fast forward-only Gaussian rasterization (`FastGaussianRenderer`,
   `render_gaussians_fast`), adapting the geometry-shader-style pipeline of
   dendenxu/fast-gaussian-rasterization to Metal compute: a fused per-Gaussian

--- a/examples/validate_gaussian_gradients.py
+++ b/examples/validate_gaussian_gradients.py
@@ -1,0 +1,116 @@
+"""Validate the Metal Gaussian rasterizer's analytic gradients numerically.
+
+The 3DGS backward pass is a hand-written Metal kernel, not autodiff. This script
+checks it against central finite differences and prints a report, so you can
+trust the training gradients (and catch regressions if you touch the kernel).
+
+For each parameter it reports the symmetric relative error between the analytic
+directional derivative ``grad . v`` and the finite-difference estimate
+``(L(x + eps v) - L(x - eps v)) / (2 eps)`` along random directions ``v``.
+
+    python examples/validate_gaussian_gradients.py
+"""
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+import mlx.core as mx
+import numpy as np
+
+from mlx3d.cameras import Camera
+from mlx3d.splatting import render_gaussians
+
+
+def loss_fn(cam, target, bg, sh_degree=0):
+    def loss(means, quats, log_scales, logit_op, sh):
+        out = render_gaussians(
+            cam,
+            means,
+            quats,
+            mx.exp(log_scales),
+            mx.sigmoid(logit_op),
+            sh=sh,
+            sh_degree=sh_degree,
+            background=bg,
+        )
+        return mx.mean((out["image"] - target) ** 2)
+
+    return loss
+
+
+def directional_report(loss, args, names, indices=None, eps=2e-3, n_dirs=6):
+    _, grads = mx.value_and_grad(loss, argnums=tuple(range(len(args))))(*args)
+    mx.eval(grads)
+    indices = range(len(args)) if indices is None else indices
+    print(
+        f"  {'param':12s} {'analytic':>13s} {'numeric':>13s} {'median rel':>12s} {'max rel':>10s}"
+    )
+    worst = 0.0
+    for i in indices:
+        name = names[i]
+        errs, a_last, n_last = [], 0.0, 0.0
+        for s in range(n_dirs):
+            mx.random.seed(500 + s)
+            v = mx.random.normal(args[i].shape)
+            a = float(mx.sum(grads[i] * v).item())
+            plus = list(args)
+            plus[i] = args[i] + eps * v
+            minus = list(args)
+            minus[i] = args[i] - eps * v
+            num = (float(loss(*plus).item()) - float(loss(*minus).item())) / (2 * eps)
+            errs.append(abs(a - num) / (abs(a) + abs(num) + 1e-8))
+            a_last, n_last = a, num
+        med, mx_err = float(np.median(errs)), float(np.max(errs))
+        worst = max(worst, med)
+        print(f"  {name:12s} {a_last:+13.3e} {n_last:+13.3e} {med:12.2e} {mx_err:10.2e}")
+    return worst
+
+
+def main():
+    cam = Camera.look_at(eye=(0, 0, -4.0), at=(0, 0, 0), width=64, height=64)
+    mx.random.seed(7)
+    target = mx.random.uniform(shape=(64, 64, 3))
+
+    print("Single isolated Gaussian (per-Gaussian gradient formulas):")
+    args = [
+        mx.array([[0.05, -0.03, 0.0]]),
+        mx.array([[1.0, 0.2, 0.1, 0.0]]),
+        mx.array([[-1.2, -1.0, -1.3]]),
+        mx.array([0.4]),
+        mx.array([[[0.3, 0.1, -0.2]]]),
+    ]
+    names = ["means", "quats", "log_scales", "opacity", "color"]
+    w1 = directional_report(loss_fn(cam, target, mx.zeros((3,))), args, names)
+
+    print("\nFour depth-stacked Gaussians (compositing colour gradient):")
+    # Only colour is finite-difference-clean under overlap; opacity/geometry are
+    # validated on the isolated Gaussian above (their FD crosses the discrete
+    # n_contrib / tile boundaries once Gaussians overlap).
+    mx.random.seed(5)
+    target2 = mx.random.uniform(shape=(64, 64, 3))
+    args2 = [
+        mx.array([[0.0, 0.0, 0.0], [0.05, 0.02, 0.3], [-0.03, 0.04, 0.6], [0.02, -0.05, 0.9]]),
+        mx.tile(mx.array([[1.0, 0.0, 0.0, 0.0]]), (4, 1)),
+        mx.full((4, 3), -1.0),
+        mx.array([0.2, -0.1, 0.3, 0.0]),
+        mx.random.normal((4, 1, 3)) * 0.5,
+    ]
+    w2 = directional_report(
+        loss_fn(cam, target2, mx.array([0.2, 0.1, 0.3])), args2, names, indices=[4]
+    )
+
+    worst = max(w1, w2)
+    print(
+        f"\nWorst median relative error: {worst:.2e}  "
+        f"({'PASS' if worst < 0.10 else 'CHECK'} — geometry ~1e-2 is finite-difference "
+        "truncation error, not a wrong gradient; per-direction max is noisier because "
+        "some directions cross discrete tile/sort boundaries)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mlx3d/splatting/rasterize.py
+++ b/src/mlx3d/splatting/rasterize.py
@@ -13,6 +13,13 @@ the tile-batched style of gsplat:
 
 The pair is wrapped in :func:`mx.custom_function`, so MLX autodiff chains
 the kernel gradients into the (pure-MLX) projection math upstream.
+
+Note: a SIMD-group-reduced backward (sum each Gaussian's per-pixel gradients
+with ``simd_sum`` and do one atomic per 32-lane group instead of up to 256)
+was tried and is ~3% *slower* on Apple GPUs — the backward is bound by the
+per-pixel recompute and the sequential transmittance walk, not by atomic
+contention, so the reduction only adds overhead. Left as one atomic per
+contributing (pixel, Gaussian) pair.
 """
 
 from __future__ import annotations

--- a/tests/test_gradcheck_rasterizer.py
+++ b/tests/test_gradcheck_rasterizer.py
@@ -1,0 +1,113 @@
+"""Finite-difference gradient check for the Metal Gaussian rasterizer.
+
+The rasterizer's backward pass is a hand-written Metal kernel (see
+``rasterize.py``), so its gradients are not produced by autodiff and deserve an
+independent correctness check. Here we compare the analytic gradient (autodiff
+through the custom VJP) against central finite differences along random
+directions, using the symmetric relative error
+``|analytic - numeric| / (|analytic| + |numeric|)`` which is robust when a
+directional derivative is near zero.
+
+Finite differences are only meaningful where the loss is smooth, so the scenes
+are built to avoid the rasterizer's genuinely non-differentiable boundaries
+(tile assignment, depth-sort order, the alpha 1/255 cutoff, transmittance
+early-termination): a single large centered Gaussian for the per-Gaussian
+geometry/appearance formulas, and a few depth-separated Gaussians for the
+multi-Gaussian compositing colour gradient.
+"""
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mlx3d.cameras import Camera
+from mlx3d.splatting import render_gaussians
+
+pytestmark = pytest.mark.unit
+
+
+def _loss_fn(cam, target, bg):
+    def loss(means, quats, log_scales, logit_op, sh_dc):
+        out = render_gaussians(
+            cam,
+            means,
+            quats,
+            mx.exp(log_scales),
+            mx.sigmoid(logit_op),
+            sh=sh_dc,
+            sh_degree=0,
+            background=bg,
+        )
+        return mx.mean((out["image"] - target) ** 2)
+
+    return loss
+
+
+def _directional_errors(loss, args, arg_index, grad, eps=2e-3, n_dirs=5, seed=200):
+    """Symmetric relative error between analytic and FD directional derivatives."""
+    errors = []
+    for s in range(n_dirs):
+        mx.random.seed(seed + s)
+        v = mx.random.normal(args[arg_index].shape)
+        analytic = float(mx.sum(grad * v).item())
+        plus = list(args)
+        plus[arg_index] = args[arg_index] + eps * v
+        minus = list(args)
+        minus[arg_index] = args[arg_index] - eps * v
+        numeric = (float(loss(*plus).item()) - float(loss(*minus).item())) / (2 * eps)
+        errors.append(abs(analytic - numeric) / (abs(analytic) + abs(numeric) + 1e-8))
+    return float(np.median(errors)), float(np.max(errors))
+
+
+def test_gradcheck_single_gaussian_all_params():
+    """Each per-Gaussian gradient formula (means, conics via quats/scales,
+    opacity, colour) matches finite differences for an isolated Gaussian."""
+    cam = Camera.look_at(eye=(0, 0, -4.0), at=(0, 0, 0), width=64, height=64)
+    mx.random.seed(7)
+    target = mx.random.uniform(shape=(64, 64, 3))
+    bg = mx.zeros((3,))
+
+    args = [
+        mx.array([[0.05, -0.03, 0.0]]),  # means
+        mx.array([[1.0, 0.2, 0.1, 0.0]]),  # quats
+        mx.array([[-1.2, -1.0, -1.3]]),  # log_scales
+        mx.array([0.4]),  # logit opacity
+        mx.array([[[0.3, 0.1, -0.2]]]),  # sh dc (colour)
+    ]
+    loss = _loss_fn(cam, target, bg)
+    _, grads = mx.value_and_grad(loss, argnums=(0, 1, 2, 3, 4))(*args)
+    mx.eval(grads)
+
+    # The median over random directions is the robust statistic: an occasional
+    # direction crosses a discrete tile/sort kink and inflates the max. Geometry
+    # gradients also carry finite-difference truncation error (the image is
+    # smooth but curved); appearance gradients are near-linear and much tighter.
+    median_tol = {0: 0.08, 1: 0.08, 2: 0.08, 3: 0.02, 4: 0.02}
+    names = ["means", "quats", "log_scales", "opacity", "color"]
+    for i, name in enumerate(names):
+        median, mx_err = _directional_errors(loss, args, i, grads[i], n_dirs=8)
+        assert median < median_tol[i], f"{name}: median rel err {median:.3f} (max {mx_err:.3f})"
+        assert mx_err < 1.5, f"{name}: catastrophic max rel err {mx_err:.3f}"
+
+
+def test_gradcheck_compositing_color():
+    """The multi-Gaussian compositing backward (front-to-back colour blending)
+    matches finite differences for depth-stacked Gaussians."""
+    cam = Camera.look_at(eye=(0, 0, -4.0), at=(0, 0, 0), width=64, height=64)
+    mx.random.seed(5)
+    target = mx.random.uniform(shape=(64, 64, 3))
+    bg = mx.array([0.2, 0.1, 0.3])
+
+    args = [
+        mx.array([[0.0, 0.0, 0.0], [0.05, 0.02, 0.3], [-0.03, 0.04, 0.6], [0.02, -0.05, 0.9]]),
+        mx.tile(mx.array([[1.0, 0.0, 0.0, 0.0]]), (4, 1)),
+        mx.full((4, 3), -1.0),
+        mx.array([0.2, -0.1, 0.3, 0.0]),
+        mx.random.normal((4, 1, 3)) * 0.5,
+    ]
+    loss = _loss_fn(cam, target, bg)
+    _, grads = mx.value_and_grad(loss, argnums=(0, 1, 2, 3, 4))(*args)
+    mx.eval(grads)
+
+    median, mx_err = _directional_errors(loss, args, 4, grads[4], n_dirs=8, seed=300)
+    assert median < 0.03, f"color: median rel err {median:.3f} (max {mx_err:.3f})"


### PR DESCRIPTION
This bundles the remaining feasible wins from the earlier review (the ones after the tile-binning speedup), validated on real data.

## `py.typed` marker

mlx3d has inline type hints throughout but no `py.typed`, so downstream users got none of the benefit — mypy/pyright ignored them. Added the marker (verified present in the built wheel). Zero-risk ergonomics win.

## Gradient-correctness harness (the gsplat-parity stand-in)

The 3DGS backward is a **hand-written Metal kernel**, not autodiff, so its gradients deserve an independent check. A true gsplat parity test needs CUDA and can't run on Apple Silicon — so this validates the analytic gradients against **finite differences** instead, which *does* run on a Mac:

- `examples/validate_gaussian_gradients.py` — a runnable report.
- `tests/test_gradcheck_rasterizer.py` — a `unit` test gating on the robust median error.

It compares the analytic directional derivative `grad·v` against central differences `(L(x+εv) − L(x−εv))/(2ε)` on scenes built to avoid the rasterizer's genuinely non-differentiable boundaries (tile assignment, depth-sort order, the α=1/255 cutoff, transmittance early-termination): a single isolated Gaussian for the per-Gaussian formulas, and depth-stacked Gaussians for the compositing colour gradient.

```
Single isolated Gaussian (per-Gaussian gradient formulas):
  param          analytic       numeric    median rel   max rel
  means        -3.705e-03    -4.068e-03      2.49e-02   8.04e-02
  quats        +1.217e-03    +1.565e-03      3.05e-02   7.03e-01
  log_scales   +3.078e-04    +3.055e-04      1.83e-02   7.66e-01
  opacity      -6.535e-04    -6.557e-04      1.47e-03   3.37e-03
  color        +1.123e-03    +1.132e-03      6.54e-03   4.44e-02
Worst median relative error: 3.05e-02  (PASS)
```

Geometry matches to ~1e-2 (finite-difference truncation, not a wrong gradient); appearance to ~1e-3. (Per-direction max is noisier because some random directions cross the discrete tile/sort boundaries — hence the median gate.)

## Negative result, documented

I also **tried the 2nd-place perf idea — a SIMD-group-reduced backward** (sum each Gaussian's per-pixel gradients with `simd_sum`, one atomic per 32-lane group instead of up to 256). It's correct (gradients matched to ~1e-10) but **~3% slower** on Apple GPUs: the backward is bound by per-pixel `exp` recompute and the sequential transmittance walk, not atomic contention, so cutting atomic traffic only adds `simd_sum` overhead. Not shipped; documented in `rasterize.py` so nobody re-treads it.

## Validation on real data

Full suite (280) green, ruff + format clean. End-to-end sanity on **Tanks & Temples truck** views: 120 optimization steps drive L1 0.19 → 0.07 and PSNR 12.7 → 19+ dB — the validated gradients optimize a real scene correctly.